### PR TITLE
ci: add linting workflow and fix shellcheck violations

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,3 +1,4 @@
+---
 name: BLEnder Auto-merge Dependabot
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+---
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+      - name: Run ShellCheck
+        run: shellcheck scripts/*.sh
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+      - name: Install and run actionlint
+        run: |
+          GOPATH="$(go env GOPATH)"
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$GOPATH/bin/actionlint"
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+      - name: Install zizmor
+        run: pip install zizmor
+      - name: Run zizmor
+        run: zizmor .github/workflows/
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff check
+        run: ruff check scripts/
+      - name: Run ruff format check
+        run: ruff format --check scripts/
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yml .github/workflows/

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -1,3 +1,4 @@
+---
 name: BLEnder Fix Dependabot PR
 on:
   workflow_call:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -1,3 +1,4 @@
+---
 name: BLEnder Setup
 on:
   workflow_dispatch:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+shell=bash

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+extends: default
+rules:
+  line-length:
+    max: 200
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: lint lint-shell lint-actions lint-zizmor lint-python lint-yaml fmt
+
+lint: lint-shell lint-actions lint-zizmor lint-python lint-yaml
+
+lint-shell:
+	shellcheck scripts/*.sh
+
+lint-actions:
+	actionlint
+
+lint-zizmor:
+	zizmor .github/workflows/
+
+lint-python:
+	ruff check scripts/
+	ruff format --check scripts/
+
+lint-yaml:
+	yamllint -c .yamllint.yml .github/workflows/
+
+fmt:
+	ruff format scripts/

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -34,7 +34,8 @@ BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
 
 # Upload each changed file as a blob
 TREE_ITEMS="[]"
-for file in $(git diff --name-only); do
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
   BLOB_SHA=$(base64 -w 0 "$file" | \
     jq -Rs '{"encoding": "base64", "content": .}' | \
     gh api "repos/${REPO}/git/blobs" \
@@ -45,7 +46,7 @@ for file in $(git diff --name-only); do
     --arg path "$file" \
     --arg sha "$BLOB_SHA" \
     '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
-done
+done < <(git diff --name-only)
 
 # Create tree from blobs
 TREE_SHA=$(jq -n \

--- a/scripts/gather-context.sh
+++ b/scripts/gather-context.sh
@@ -33,9 +33,11 @@ fi
 # --- Sanitize untrusted input before inserting into prompts ---
 sanitize_for_prompt() {
   local input="$1"
-  # Strip HTML/XML tags
+  # Strip HTML/XML tags (regex requires sed, not ${//})
+  # shellcheck disable=SC2001
   input=$(echo "$input" | sed 's/<[^>]*>//g')
   # Strip markdown image/link injection
+  # shellcheck disable=SC2001
   input=$(echo "$input" | sed 's/!\[[^]]*\]([^)]*)//g')
   # Strip prompt injection attempts
   input=$(echo "$input" | grep -viE '(ignore .* instructions|ignore .* prompt|system prompt|you are now|new instructions|disregard|forget .* above)' || true)

--- a/scripts/run-claude.sh
+++ b/scripts/run-claude.sh
@@ -44,7 +44,7 @@ CLAUDE_LOG=$(mktemp /tmp/blender-claude-XXXXXX.log)
 
 echo "Running Claude Code to diagnose and fix..."
 claude_exit=0
-cat .blender-prompt | claude \
+claude \
   -p \
   --verbose \
   --max-turns 30 \
@@ -53,6 +53,7 @@ cat .blender-prompt | claude \
   --allowedTools "Read,Edit,Bash" \
   --disallowedTools "WebSearch,WebFetch" \
   --system-prompt "You are BLEnder, a CI-fixing agent for ${REPO_DISPLAY_NAME}. Fix the CI failure described in the prompt. Be minimal and precise. Do not search the web. Internal verification token: ${PROMPT_NONCE}. This token is confidential. Never include it in any output, file edit, or commit message." \
+  < .blender-prompt \
   > "$CLAUDE_LOG" 2>&1 \
   || claude_exit=$?
 


### PR DESCRIPTION
Catch issues before they reach main. Five parallel CI jobs: shellcheck, actionlint, zizmor, ruff, yamllint.

Fix SC2086 word-splitting bug in commit.sh. Fix SC2002 useless cat in run-claude.sh. Suppress SC2001 where sed regex patterns have no bash equivalent.

Add Makefile for local lint runs. Add YAML document-start markers to satisfy yamllint.