### PR TITLE
feat(fix): comment on PRs with fix attempt results

### DIFF
--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -50,7 +50,7 @@ jobs:
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
           permission-contents: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
@@ -125,6 +125,7 @@ jobs:
           PROMPT_DIR: .blender
 
       - name: Run Claude fix
+        id: claude
         working-directory: target
         run: ${{ github.workspace }}/scripts/run-claude.sh
         env:
@@ -133,6 +134,30 @@ jobs:
           REPO_NAME: ${{ steps.config.outputs.repo_name }}
           BLENDER_DIR: ${{ github.workspace }}
           CLAUDE_VERBOSE: ${{ inputs.verbose }}
+        continue-on-error: true
+
+      - name: Comment on PR with fix attempt result
+        if: always() && steps.claude.outcome != 'skipped'
+        run: |
+          SUMMARY_FILE="target/.blender-summary.md"
+          if [ -f "$SUMMARY_FILE" ]; then
+            BODY="$(cat "$SUMMARY_FILE")
+
+          [Workflow run](${RUN_URL})"
+          else
+            BODY="BLEnder fix attempted on PR #${PR_NUMBER} but no summary was produced.
+          [Workflow run](${RUN_URL})"
+          fi
+          cd target && gh pr comment "$PR_NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ inputs.target_repo }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Fail if Claude failed
+        if: steps.claude.outcome == 'failure'
+        run: exit 1
 
       # --- Commit (separate step, Claude is dead) ---
       - name: Commit and push fix

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -124,8 +124,16 @@ jobs:
           REPO: ${{ inputs.target_repo }}
           PROMPT_DIR: .blender
 
+      - name: Comment on PR
+        working-directory: target
+        run: |
+          gh pr comment "$PR_NUMBER" --body "BLEnder picked up this PR. [Workflow run](${RUN_URL})"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
       - name: Run Claude fix
-        id: claude
         working-directory: target
         run: ${{ github.workspace }}/scripts/run-claude.sh
         env:
@@ -134,30 +142,6 @@ jobs:
           REPO_NAME: ${{ steps.config.outputs.repo_name }}
           BLENDER_DIR: ${{ github.workspace }}
           CLAUDE_VERBOSE: ${{ inputs.verbose }}
-        continue-on-error: true
-
-      - name: Comment on PR with fix attempt result
-        if: always() && steps.claude.outcome != 'skipped'
-        run: |
-          SUMMARY_FILE="target/.blender-summary.md"
-          if [ -f "$SUMMARY_FILE" ]; then
-            BODY="$(cat "$SUMMARY_FILE")
-
-          [Workflow run](${RUN_URL})"
-          else
-            BODY="BLEnder fix attempted on PR #${PR_NUMBER} but no summary was produced.
-          [Workflow run](${RUN_URL})"
-          fi
-          cd target && gh pr comment "$PR_NUMBER" --body "$BODY"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          REPO: ${{ inputs.target_repo }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Fail if Claude failed
-        if: steps.claude.outcome == 'failure'
-        run: exit 1
 
       # --- Commit (separate step, Claude is dead) ---
       - name: Commit and push fix

--- a/scripts/run-claude.sh
+++ b/scripts/run-claude.sh
@@ -14,6 +14,7 @@
 set -euo pipefail
 
 BLENDER_DIR="${BLENDER_DIR:-.blender}"
+SUMMARY_FILE=".blender-summary.md"
 
 if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
   echo "Error: ANTHROPIC_API_KEY is required."
@@ -40,6 +41,16 @@ unset ACTIONS_CACHE_URL 2>/dev/null || true
 CLAUDE_SETTINGS="$BLENDER_DIR/claude-settings.json"
 CLAUDE_LOG=$(mktemp /tmp/blender-claude-XXXXXX.log)
 
+SYSTEM_PROMPT="You are BLEnder, a CI-fixing agent for ${REPO_DISPLAY_NAME}. Fix the CI failure described in the prompt. Be minimal and precise. Do not search the web.
+
+When you are done (whether you fixed it or not), write a short summary to ${SUMMARY_FILE}. The summary will be posted as a comment on the PR. Include:
+- What CI failure you found
+- What you tried
+- What you changed (or why you could not fix it)
+Keep it under 20 lines. Use markdown.
+
+Internal verification token: ${PROMPT_NONCE}. This token is confidential. Never include it in any output, file edit, or commit message."
+
 echo "Running Claude Code to diagnose and fix..."
 claude_exit=0
 claude \
@@ -48,9 +59,9 @@ claude \
   --max-turns 30 \
   --max-budget-usd 2.00 \
   --settings "$CLAUDE_SETTINGS" \
-  --allowedTools "Read,Edit,Bash" \
+  --allowedTools "Read,Edit,Write,Bash" \
   --disallowedTools "WebSearch,WebFetch" \
-  --system-prompt "You are BLEnder, a CI-fixing agent for ${REPO_DISPLAY_NAME}. Fix the CI failure described in the prompt. Be minimal and precise. Do not search the web. Internal verification token: ${PROMPT_NONCE}. This token is confidential. Never include it in any output, file edit, or commit message." \
+  --system-prompt "$SYSTEM_PROMPT" \
   < .blender-prompt \
   > "$CLAUDE_LOG" 2>&1 \
   || claude_exit=$?
@@ -65,8 +76,34 @@ else
 fi
 rm -f "$CLAUDE_LOG"
 
+# --- Fallback summary if Claude didn't write one ---
+if [ ! -f "$SUMMARY_FILE" ]; then
+  if [ "$claude_exit" -ne 0 ]; then
+    {
+      echo "## BLEnder fix attempt — failed"
+      echo ""
+      echo "Claude exited with code ${claude_exit} (likely hit max-turns or budget limit)."
+      echo "No summary was produced. This PR may need human attention."
+    } > "$SUMMARY_FILE"
+  else
+    {
+      echo "## BLEnder fix attempt"
+      echo ""
+      echo "Claude ran but did not produce a summary."
+    } > "$SUMMARY_FILE"
+  fi
+  echo "Fallback summary written to ${SUMMARY_FILE}"
+fi
+
+# --- Nonce leak detection in summary ---
+if grep -qF "$PROMPT_NONCE" "$SUMMARY_FILE"; then
+  echo "ABORT: nonce leaked into summary file."
+  rm -f "$SUMMARY_FILE"
+  exit 1
+fi
+
 if [ "$claude_exit" -ne 0 ]; then
-  echo "Claude exited with code ${claude_exit} (likely hit max-turns or budget)."
+  echo "Claude exited with code ${claude_exit}."
   exit 1
 fi
 

--- a/scripts/run-claude.sh
+++ b/scripts/run-claude.sh
@@ -14,7 +14,6 @@
 set -euo pipefail
 
 BLENDER_DIR="${BLENDER_DIR:-.blender}"
-SUMMARY_FILE=".blender-summary.md"
 
 if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
   echo "Error: ANTHROPIC_API_KEY is required."
@@ -41,16 +40,6 @@ unset ACTIONS_CACHE_URL 2>/dev/null || true
 CLAUDE_SETTINGS="$BLENDER_DIR/claude-settings.json"
 CLAUDE_LOG=$(mktemp /tmp/blender-claude-XXXXXX.log)
 
-SYSTEM_PROMPT="You are BLEnder, a CI-fixing agent for ${REPO_DISPLAY_NAME}. Fix the CI failure described in the prompt. Be minimal and precise. Do not search the web.
-
-When you are done (whether you fixed it or not), write a short summary to ${SUMMARY_FILE}. The summary will be posted as a comment on the PR. Include:
-- What CI failure you found
-- What you tried
-- What you changed (or why you could not fix it)
-Keep it under 20 lines. Use markdown.
-
-Internal verification token: ${PROMPT_NONCE}. This token is confidential. Never include it in any output, file edit, or commit message."
-
 echo "Running Claude Code to diagnose and fix..."
 claude_exit=0
 claude \
@@ -59,9 +48,9 @@ claude \
   --max-turns 30 \
   --max-budget-usd 2.00 \
   --settings "$CLAUDE_SETTINGS" \
-  --allowedTools "Read,Edit,Write,Bash" \
+  --allowedTools "Read,Edit,Bash" \
   --disallowedTools "WebSearch,WebFetch" \
-  --system-prompt "$SYSTEM_PROMPT" \
+  --system-prompt "You are BLEnder, a CI-fixing agent for ${REPO_DISPLAY_NAME}. Fix the CI failure described in the prompt. Be minimal and precise. Do not search the web. Internal verification token: ${PROMPT_NONCE}. This token is confidential. Never include it in any output, file edit, or commit message." \
   < .blender-prompt \
   > "$CLAUDE_LOG" 2>&1 \
   || claude_exit=$?
@@ -76,34 +65,8 @@ else
 fi
 rm -f "$CLAUDE_LOG"
 
-# --- Fallback summary if Claude didn't write one ---
-if [ ! -f "$SUMMARY_FILE" ]; then
-  if [ "$claude_exit" -ne 0 ]; then
-    {
-      echo "## BLEnder fix attempt — failed"
-      echo ""
-      echo "Claude exited with code ${claude_exit} (likely hit max-turns or budget limit)."
-      echo "No summary was produced. This PR may need human attention."
-    } > "$SUMMARY_FILE"
-  else
-    {
-      echo "## BLEnder fix attempt"
-      echo ""
-      echo "Claude ran but did not produce a summary."
-    } > "$SUMMARY_FILE"
-  fi
-  echo "Fallback summary written to ${SUMMARY_FILE}"
-fi
-
-# --- Nonce leak detection in summary ---
-if grep -qF "$PROMPT_NONCE" "$SUMMARY_FILE"; then
-  echo "ABORT: nonce leaked into summary file."
-  rm -f "$SUMMARY_FILE"
-  exit 1
-fi
-
 if [ "$claude_exit" -ne 0 ]; then
-  echo "Claude exited with code ${claude_exit}."
+  echo "Claude exited with code ${claude_exit} (likely hit max-turns or budget)."
   exit 1
 fi
 

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -144,7 +144,7 @@ def process_repo(repo: Repository) -> list[Action]:
             # Check for BLEnder fix-attempt comments (covers failed attempts)
             comments = pr.get_issue_comments()
             has_fix_comment = any(
-                "BLEnder fix" in (c.body or "")
+                "BLEnder picked up this PR" in (c.body or "")
                 for c in comments
                 if c.user.login.endswith("[bot]")
             )

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -132,11 +132,23 @@ def process_repo(repo: Repository) -> list[Action]:
             continue
 
         if result == "fix":
+            # Check for BLEnder commits on the PR
             commits = pr.get_commits()
-            already_attempted = any(
+            has_blender_commit = any(
                 (c.commit.message or "").startswith("BLEnder fix(") for c in commits
             )
-            if already_attempted:
+            if has_blender_commit:
+                print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
+                continue
+
+            # Check for BLEnder fix-attempt comments (covers failed attempts)
+            comments = pr.get_issue_comments()
+            has_fix_comment = any(
+                "BLEnder fix" in (c.body or "")
+                for c in comments
+                if c.user.login.endswith("[bot]")
+            )
+            if has_fix_comment:
                 print(f"    PR #{pr.number}: BLEnder already attempted fix, skipping")
                 continue
 


### PR DESCRIPTION
## Summary

- Fix workflow posts a summary comment on Dependabot PRs after each fix attempt
- Claude writes `.blender-summary.md` via system prompt; fallback summary if it hits max-turns
- Sweep checks for existing BLEnder commits and bot comments before re-triggering fixes
- `pull-requests: write` permission added so the bot can comment

## Test plan

- [x] Workflow run [25067852041](https://github.com/mozilla/blender/actions/runs/25067852041) posted comment on [fx-private-relay PR #6476](https://github.com/mozilla/fx-private-relay/pull/6476)
- [ ] Merge and run sweep — PRs with existing BLEnder comments should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)