### PR TITLE
fix(sweep): check all BLEnder comments before dispatching fix

### DIFF
--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -141,15 +141,20 @@ def process_repo(repo: Repository) -> list[Action]:
                 print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
                 continue
 
-            # Check for BLEnder fix-attempt comments (covers failed attempts)
+            # Check for any BLEnder comment (covers fix attempts AND
+            # automerge skip/reject decisions like "will not auto-merge")
             comments = pr.get_issue_comments()
-            has_fix_comment = any(
-                "BLEnder picked up this PR" in (c.body or "")
-                for c in comments
-                if c.user.login.endswith("[bot]")
+            blender_comment = next(
+                (
+                    c.body
+                    for c in comments
+                    if c.user.login.endswith("[bot]")
+                    and (c.body or "").startswith("BLEnder")
+                ),
+                None,
             )
-            if has_fix_comment:
-                print(f"    PR #{pr.number}: BLEnder already attempted fix, skipping")
+            if blender_comment:
+                print(f"    PR #{pr.number}: BLEnder already commented, skipping")
                 continue
 
         print(f"    PR #{pr.number}: {result}")


### PR DESCRIPTION
## Summary
- Sweep only checked for "BLEnder picked up this PR" comments when deciding to skip a PR
- Automerge comments like "BLEnder: will not auto-merge (major version bump on eslint)" were ignored
- This caused repeated fix attempts on PRs already rejected by automerge (e.g. blurts-server PR #6566)
- Now checks for any bot comment starting with "BLEnder"

## Test plan
- [ ] Verify sweep skips PRs with "BLEnder: will not auto-merge" comments
- [ ] Verify sweep still skips PRs with "BLEnder picked up this PR" comments
- [ ] Verify sweep still processes PRs with no BLEnder comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)