### PR TITLE
feat(automerge): comment @dependabot recreate on advisory-blocked PRs

### DIFF
--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -38,6 +38,10 @@ class RetryPR(SkipPR):
     """Score-related skip that may resolve on a future run."""
 
 
+class AdvisorySkipPR(SkipPR):
+    """Skip caused by a GHSA advisory on the new version."""
+
+
 @dataclass
 class DependencyUpdate:
     """Structured metadata from Dependabot's commit message YAML."""
@@ -541,7 +545,7 @@ def gate_advisories(gh: Github, meta: PRMetadata) -> None:
 
         affecting = _find_affecting_advisories(advisories, dep, meta.ecosystem)
         if affecting:
-            raise SkipPR(
+            raise AdvisorySkipPR(
                 f"{len(affecting)} security advisory(ies) affect "
                 f"{dep.name}@{dep.version}: {', '.join(affecting)}"
             )
@@ -678,6 +682,15 @@ def _post_skip_comment(
         print(f"  Posted comment on PR #{pr.number}")
 
 
+def _post_dependabot_recreate(pr: PullRequest, dry_run: bool) -> None:
+    """Ask Dependabot to recreate the PR with a newer version."""
+    if dry_run:
+        print(f"  DRY_RUN: would comment @dependabot recreate on PR #{pr.number}")
+        return
+    pr.create_issue_comment("@dependabot recreate")
+    print(f"  Posted @dependabot recreate on PR #{pr.number}")
+
+
 def _print_summary(
     merged: int, skipped: int, skip_reasons: list[str], dry_run: bool
 ) -> None:
@@ -736,6 +749,9 @@ def main() -> None:
             skip_reasons.append(f"#{pr.number} ({pkg}): {tag}{e}")
 
             _post_skip_comment(pr, str(e), is_retry, config.dry_run)
+
+            if isinstance(e, AdvisorySkipPR):
+                _post_dependabot_recreate(pr, config.dry_run)
 
     _print_summary(merged, skipped, skip_reasons, config.dry_run)
 

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -1,11 +1,19 @@
-"""Tests for version_in_range and its helpers."""
+"""Tests for scripts.automerge_dependabot."""
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from scripts.automerge_dependabot import (
+    AdvisorySkipPR,
+    DependencyUpdate,
+    PRMetadata,
+    SkipPR,
     _normalize_pep440_range,
+    _post_dependabot_recreate,
+    gate_advisories,
     version_in_range,
 )
 
@@ -134,3 +142,87 @@ class TestVersionInRangeFallback:
         """
         assert version_in_range("not_a_version", "not_a_range", "") is False
         assert version_in_range("", "", "") is False
+
+
+# --- gate_advisories raises AdvisorySkipPR ---
+
+
+def test_gate_advisories_raises_advisory_skip_pr():
+    """Advisory on the new version raises AdvisorySkipPR, not bare SkipPR."""
+    meta = PRMetadata(
+        dependencies=[
+            DependencyUpdate(
+                name="lodash",
+                version="4.17.20",
+                dependency_type="direct:production",
+                update_type="version-update:semver-patch",
+            )
+        ],
+        ecosystem="npm",
+        raw_ecosystem="npm_and_yarn",
+    )
+
+    vuln = MagicMock()
+    vuln.vulnerable_version_range = ">= 4.0.0, < 4.17.21"
+    vuln.package = MagicMock()
+    vuln.package.name = "lodash"
+
+    advisory = MagicMock()
+    advisory.ghsa_id = "GHSA-abcd-1234-efgh"
+    advisory.vulnerabilities = [vuln]
+
+    gh = MagicMock()
+    gh.get_global_advisories.return_value = [advisory]
+
+    with pytest.raises(AdvisorySkipPR, match="GHSA-abcd-1234-efgh"):
+        gate_advisories(gh, meta)
+
+
+# --- _post_dependabot_recreate ---
+
+
+def test_post_dependabot_recreate_comment_text():
+    """Exact text matters — Dependabot parses commands literally."""
+    pr = MagicMock()
+    pr.number = 42
+    _post_dependabot_recreate(pr, dry_run=False)
+    pr.create_issue_comment.assert_called_once_with("@dependabot recreate")
+
+
+# --- main loop: advisory skip triggers recreate, regular skip does not ---
+
+
+@pytest.mark.parametrize(
+    "exception, expect_recreate",
+    [
+        (AdvisorySkipPR("advisory on lodash@4.17.20"), True),
+        (SkipPR("major version bump"), False),
+    ],
+)
+@patch("scripts.automerge_dependabot.process_pr")
+def test_main_loop_recreate_on_advisory_skip_only(
+    mock_process, exception, expect_recreate, monkeypatch,
+):
+    from scripts.automerge_dependabot import main
+
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+
+    pr = MagicMock()
+    pr.number = 7
+    pr.user.login = "dependabot[bot]"
+    pr.head.ref = "dependabot/npm_and_yarn/lodash-4.17.21"
+    pr.get_issue_comments.return_value = []
+
+    mock_process.side_effect = exception
+
+    with patch("scripts.automerge_dependabot.Github") as gh_cls:
+        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
+        main()
+
+    recreate_calls = [
+        c for c in pr.create_issue_comment.call_args_list
+        if c.args[0] == "@dependabot recreate"
+    ]
+    assert len(recreate_calls) == (1 if expect_recreate else 0)


### PR DESCRIPTION
When a Dependabot PR targets a version still affected by a GHSA advisory, post @dependabot recreate so Dependabot closes the stale PR and opens a fresh one targeting the latest available version.