### PR TITLE
fix: handle direct script invocation for github_utils import

### DIFF
--- a/.github/workflows/chore-automerge-dependabot-prs.yml
+++ b/.github/workflows/chore-automerge-dependabot-prs.yml
@@ -88,6 +88,7 @@ jobs:
             new_version=$(echo "$bump" | jq -r '.new_version')
             echo "Dispatching review for PR #${pr_number} (${dep_name} ${new_version})..."
             gh workflow run chore-review-major-dependabot-update.yml \
+              --ref "$REF" \
               --field target_repo="$TARGET_REPO" \
               --field pr_number="$pr_number" \
               --field dep_name="$dep_name" \
@@ -96,6 +97,7 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
           TARGET_REPO: ${{ inputs.target_repo }}
           MAJOR_BUMPS: ${{ steps.run-automerge.outputs.major_bumps }}
           DRY_RUN: ${{ inputs.dry_run || 'true' }}

--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -111,6 +111,10 @@ jobs:
           python-version: ${{ steps.config.outputs.python_version || '3.11' }}
           cache: pip
 
+      - name: Install BLEnder Python dependencies
+        run: pip install -r scripts/requirements.txt
+        working-directory: ${{ github.workspace }}
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         if: steps.config.outputs.node_version != ''
         with:

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -28,7 +28,10 @@ from github.PullRequest import PullRequest
 from github.Repository import Repository
 import nodesemver
 
-from scripts.github_utils import enable_auto_merge
+try:
+    from scripts.github_utils import enable_auto_merge
+except ModuleNotFoundError:
+    from github_utils import enable_auto_merge
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 

--- a/scripts/post_major_review.py
+++ b/scripts/post_major_review.py
@@ -25,7 +25,10 @@ import sys
 from github import Auth, Github
 from github.PullRequest import PullRequest
 
-from scripts.github_utils import enable_auto_merge
+try:
+    from scripts.github_utils import enable_auto_merge
+except ModuleNotFoundError:
+    from github_utils import enable_auto_merge
 
 VERDICT_FILE = ".blender-verdict.json"
 


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError: No module named 'scripts'` when workflows run `python scripts/automerge_dependabot.py` directly
- Add fallback sibling import for `github_utils` when `scripts` package isn't on `sys.path`

Found by: dry run on mozilla/fx-private-relay — https://github.com/mozilla/blender/actions/runs/25192977790/job/73867084895

## Test plan
- [x] Re-run automerge dry run on fx-private-relay
- [x] Verify `python -m pytest tests/` still passes (tested locally, 33 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)