### PR TITLE
fix: stop duplicate review dispatches for major bumps

### DIFF
--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -98,7 +98,15 @@ jobs:
 
       - name: Comment on PR
         run: |
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "BLEnder is reviewing this major version bump. [Workflow run](${RUN_URL})"
+          # Skip the "reviewing" comment if blender[bot] already commented.
+          # The review itself still runs — this only prevents duplicate comments.
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.user.login == "blender[bot]")] | length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "blender[bot] comment already exists, skipping comment."
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "Reviewing this major version bump. [Workflow run](${RUN_URL})"
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -29,9 +29,9 @@ from github.Repository import Repository
 import nodesemver
 
 try:
-    from scripts.github_utils import enable_auto_merge
+    from scripts.github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict
 except ModuleNotFoundError:
-    from github_utils import enable_auto_merge
+    from github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
@@ -664,7 +664,7 @@ def _post_skip_comment(
     already_commented = any(
         c.body.startswith("BLEnder: ")
         for c in pr.get_issue_comments()
-        if c.user.login.endswith("[bot]")
+        if c.user.login == BOT_LOGIN
     )
     if already_commented:
         print(f"  BLEnder comment already exists on PR #{pr.number}")
@@ -753,19 +753,21 @@ def main() -> None:
             pkg = _package_name_from_branch(pr.head.ref)
             skip_reasons.append(f"#{pr.number} ({pkg}): {e}")
 
-            major_bumps.append(
-                {
-                    "pr_number": pr.number,
-                    "dep_name": e.dep.name,
-                    "old_version": e.meta.old_version or e.dep.old_version,
-                    "new_version": e.dep.version,
-                    "ecosystem": e.meta.ecosystem,
-                    "raw_ecosystem": e.meta.raw_ecosystem,
-                    "pr_title": pr.title,
-                }
-            )
-
-            if not review_major:
+            if review_major and has_blender_verdict(pr):
+                print("  Already reviewed by BLEnder, skipping dispatch.")
+            elif review_major:
+                major_bumps.append(
+                    {
+                        "pr_number": pr.number,
+                        "dep_name": e.dep.name,
+                        "old_version": e.meta.old_version or e.dep.old_version,
+                        "new_version": e.dep.version,
+                        "ecosystem": e.meta.ecosystem,
+                        "raw_ecosystem": e.meta.raw_ecosystem,
+                        "pr_title": pr.title,
+                    }
+                )
+            else:
                 _post_skip_comment(pr, str(e), False, config.dry_run)
 
         except SkipPR as e:

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -2,7 +2,58 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 from github.PullRequest import PullRequest
+
+
+BOT_LOGIN = "blender[bot]"
+
+
+class Verdict(Enum):
+    """Review verdict codes and their comment messages.
+
+    The enum *name* (e.g. ``SAFE``) is the stable tag written at the
+    start of every comment.  Dedup checks match on ``"SAFE:"``, so
+    changing a name is a breaking change.  The *value* is the human-
+    readable message that follows the tag.
+    """
+
+    SAFE = "major version bump is safe"
+    NEEDS_REVIEW = "this major version bump needs human review"
+    NO_VERDICT = "could not evaluate this major version bump"
+    MALFORMED = "verdict file was malformed"
+    APPROVED = "auto-merge: major bump evaluated as safe"
+
+    def comment(self, detail: str = "") -> str:
+        """Build a comment string: ``TAG: message [detail]``."""
+        text = f"{self.name}: {self.value}"
+        if detail:
+            text = f"{text} {detail}"
+        return text
+
+    @classmethod
+    def tags(cls) -> tuple[str, ...]:
+        """All verdict tag prefixes (e.g. ``"SAFE:"``) for matching."""
+        return tuple(f"{v.name}:" for v in cls)
+
+
+def has_blender_verdict(pr: PullRequest) -> bool:
+    """True if BLEnder already posted a review verdict on this PR."""
+    tags = Verdict.tags()
+    for c in pr.get_issue_comments():
+        if c.user.login != BOT_LOGIN:
+            continue
+        if any(c.body.startswith(t) for t in tags):
+            return True
+    for r in pr.get_reviews():
+        if (
+            r.user.login == BOT_LOGIN
+            and r.body
+            and any(r.body.startswith(t) for t in tags)
+        ):
+            return True
+    return False
 
 
 def enable_auto_merge(pr: PullRequest) -> None:

--- a/scripts/post_major_review.py
+++ b/scripts/post_major_review.py
@@ -26,9 +26,9 @@ from github import Auth, Github
 from github.PullRequest import PullRequest
 
 try:
-    from scripts.github_utils import enable_auto_merge
+    from scripts.github_utils import Verdict, enable_auto_merge, has_blender_verdict
 except ModuleNotFoundError:
-    from github_utils import enable_auto_merge
+    from github_utils import Verdict, enable_auto_merge, has_blender_verdict
 
 VERDICT_FILE = ".blender-verdict.json"
 
@@ -37,14 +37,15 @@ def post_comment(pr: PullRequest, body: str, dry_run: bool) -> None:
     if dry_run:
         print(f"DRY_RUN: would comment:\n{body}")
         return
+    if has_blender_verdict(pr):
+        print("Verdict comment already exists, skipping duplicate.")
+        return
     pr.create_issue_comment(body)
 
 
 def approve_and_merge(pr: PullRequest, confidence: str, dry_run: bool) -> None:
     """Approve the PR and enable auto-merge."""
-    review_body = (
-        f"BLEnder auto-merge: major bump evaluated as safe ({confidence} confidence)."
-    )
+    review_body = Verdict.APPROVED.comment(f"({confidence} confidence).")
     if dry_run:
         print("DRY_RUN: would approve and enable auto-merge")
         return
@@ -71,7 +72,7 @@ def main() -> None:
         print("No verdict file found. Claude could not evaluate this bump.")
         post_comment(
             pr,
-            "BLEnder: could not evaluate this major version bump. Manual review needed.",
+            Verdict.NO_VERDICT.comment("— manual review needed."),
             dry_run,
         )
         return
@@ -85,7 +86,7 @@ def main() -> None:
         print(f"Error reading verdict: {exc}")
         post_comment(
             pr,
-            "BLEnder: verdict file was malformed. Manual review needed.",
+            Verdict.MALFORMED.comment("— manual review needed."),
             dry_run,
         )
         return
@@ -102,7 +103,7 @@ def main() -> None:
 
     if safe and confidence != "low":
         comment = (
-            "BLEnder: major version bump is safe to merge.\n\n"
+            f"{Verdict.SAFE.comment('to merge.')}\n\n"
             f"**Confidence:** {confidence}\n"
             f"**Reason:** {reason}\n\n"
             f"**Breaking changes:** "
@@ -115,7 +116,7 @@ def main() -> None:
             print("Done. PR approved and auto-merge enabled.")
     else:
         comment = (
-            "BLEnder: this major version bump needs human review.\n\n"
+            f"{Verdict.NEEDS_REVIEW.comment()}\n\n"
             f"**Confidence:** {confidence}\n"
             f"**Reason:** {reason}\n\n"
             f"**Breaking changes:** {breaking_changes or 'None identified'}\n"

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -356,8 +356,8 @@ def test_main_no_comment_when_review_major(mock_process, monkeypatch):
 # --- has_blender_verdict ---
 
 
-def _make_mock(body: str, login: str = "blender[bot]"):
-    """Build a mock PR comment or review with the given body and login."""
+def _gh_comment(body: str, login: str = "blender[bot]"):
+    """Build a mock GitHub comment/review object with .body and .user.login."""
     m = MagicMock()
     m.body = body
     m.user.login = login
@@ -370,7 +370,7 @@ def _make_mock(body: str, login: str = "blender[bot]"):
 )
 def test_has_blender_verdict_from_comment(verdict):
     pr = MagicMock()
-    pr.get_issue_comments.return_value = [_make_mock(verdict.comment("extra."))]
+    pr.get_issue_comments.return_value = [_gh_comment(body=verdict.comment("extra."))]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is True
 
@@ -379,7 +379,7 @@ def test_has_blender_verdict_from_review():
     pr = MagicMock()
     pr.get_issue_comments.return_value = []
     pr.get_reviews.return_value = [
-        _make_mock(Verdict.APPROVED.comment("(high confidence)."))
+        _gh_comment(body=Verdict.APPROVED.comment("(high confidence)."))
     ]
     assert has_blender_verdict(pr) is True
 
@@ -387,7 +387,7 @@ def test_has_blender_verdict_from_review():
 def test_has_blender_verdict_false_when_no_verdict():
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _make_mock("Reviewing this major version bump.")
+        _gh_comment(body="Reviewing this major version bump.")
     ]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is False
@@ -396,7 +396,7 @@ def test_has_blender_verdict_false_when_no_verdict():
 def test_has_blender_verdict_ignores_human_comments():
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _make_mock(Verdict.SAFE.comment("to merge."), login="groovecoder")
+        _gh_comment(body=Verdict.SAFE.comment("to merge."), login="groovecoder")
     ]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is False
@@ -442,7 +442,7 @@ def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tm
     pr.head.ref = "dependabot/pip/ipware-7.0.0"
     # Simulate existing verdict comment
     pr.get_issue_comments.return_value = [
-        _make_mock(Verdict.NO_VERDICT.comment("Manual review needed."))
+        _gh_comment(body=Verdict.NO_VERDICT.comment("Manual review needed."))
     ]
     pr.get_reviews.return_value = []
 

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -18,6 +18,7 @@ from scripts.automerge_dependabot import (
     gate_versions,
     version_in_range,
 )
+from scripts.github_utils import Verdict, has_blender_verdict
 
 
 # --- _normalize_pep440_range ---
@@ -300,6 +301,7 @@ def test_main_outputs_major_bumps_json(mock_process, monkeypatch, tmp_path):
     pr.user.login = "dependabot[bot]"
     pr.head.ref = "dependabot/pip/ipware-7.0.0"
     pr.get_issue_comments.return_value = []
+    pr.get_reviews.return_value = []
 
     with patch("scripts.automerge_dependabot.Github") as gh_cls:
         gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
@@ -342,9 +344,112 @@ def test_main_no_comment_when_review_major(mock_process, monkeypatch):
     pr.user.login = "dependabot[bot]"
     pr.head.ref = "dependabot/pip/ipware-7.0.0"
     pr.get_issue_comments.return_value = []
+    pr.get_reviews.return_value = []
 
     with patch("scripts.automerge_dependabot.Github") as gh_cls:
         gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
         main()
 
     pr.create_issue_comment.assert_not_called()
+
+
+# --- has_blender_verdict ---
+
+
+def _make_mock(body: str, login: str = "blender[bot]"):
+    """Build a mock PR comment or review with the given body and login."""
+    m = MagicMock()
+    m.body = body
+    m.user.login = login
+    return m
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [Verdict.SAFE, Verdict.NEEDS_REVIEW, Verdict.NO_VERDICT, Verdict.MALFORMED],
+)
+def test_has_blender_verdict_from_comment(verdict):
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = [_make_mock(verdict.comment("extra."))]
+    pr.get_reviews.return_value = []
+    assert has_blender_verdict(pr) is True
+
+
+def test_has_blender_verdict_from_review():
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = []
+    pr.get_reviews.return_value = [
+        _make_mock(Verdict.APPROVED.comment("(high confidence)."))
+    ]
+    assert has_blender_verdict(pr) is True
+
+
+def test_has_blender_verdict_false_when_no_verdict():
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = [
+        _make_mock("Reviewing this major version bump.")
+    ]
+    pr.get_reviews.return_value = []
+    assert has_blender_verdict(pr) is False
+
+
+def test_has_blender_verdict_ignores_human_comments():
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = [
+        _make_mock(Verdict.SAFE.comment("to merge."), login="groovecoder")
+    ]
+    pr.get_reviews.return_value = []
+    assert has_blender_verdict(pr) is False
+
+
+@patch("scripts.automerge_dependabot.process_pr")
+def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tmp_path):
+    """Already-reviewed major bumps are not dispatched again."""
+    from scripts.automerge_dependabot import main
+
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.setenv("REVIEW_MAJOR", "true")
+
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    dep = DependencyUpdate(
+        name="ipware",
+        version="7.0.0",
+        dependency_type="direct:production",
+        update_type="version-update:semver-major",
+        old_version="6.0.5",
+    )
+    meta = PRMetadata(
+        dependencies=[dep],
+        has_major=True,
+        ecosystem="pip",
+        raw_ecosystem="pip",
+        old_version="6.0.5",
+        new_version="7.0.0",
+    )
+    mock_process.side_effect = MajorBumpPR(
+        "major version bump on ipware", dep=dep, meta=meta
+    )
+
+    pr = MagicMock()
+    pr.number = 42
+    pr.title = "Bump ipware from 6.0.5 to 7.0.0"
+    pr.user.login = "dependabot[bot]"
+    pr.head.ref = "dependabot/pip/ipware-7.0.0"
+    # Simulate existing verdict comment
+    pr.get_issue_comments.return_value = [
+        _make_mock(Verdict.NO_VERDICT.comment("Manual review needed."))
+    ]
+    pr.get_reviews.return_value = []
+
+    with patch("scripts.automerge_dependabot.Github") as gh_cls:
+        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
+        main()
+
+    # No major_bumps output written
+    output = output_file.read_text()
+    assert "major_bumps=" not in output

--- a/tests/scripts/test_post_major_review.py
+++ b/tests/scripts/test_post_major_review.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from scripts.github_utils import Verdict
 from scripts.post_major_review import main
-from tests.scripts.test_automerge_dependabot import _make_mock
+from tests.scripts.test_automerge_dependabot import _gh_comment
 
 
 @patch("scripts.post_major_review.Github")
@@ -36,7 +36,7 @@ def test_no_duplicate_verdict_comment(mock_gh_cls, monkeypatch, tmp_path):
 
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _make_mock(Verdict.NEEDS_REVIEW.comment())
+        _gh_comment(body=Verdict.NEEDS_REVIEW.comment())
     ]
     pr.get_reviews.return_value = []
     mock_gh_cls.return_value.get_repo.return_value.get_pull.return_value = pr

--- a/tests/scripts/test_post_major_review.py
+++ b/tests/scripts/test_post_major_review.py
@@ -1,0 +1,85 @@
+"""Tests for scripts.post_major_review."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from scripts.github_utils import Verdict
+from scripts.post_major_review import main
+from tests.scripts.test_automerge_dependabot import _make_mock
+
+
+@patch("scripts.post_major_review.Github")
+def test_no_duplicate_verdict_comment(mock_gh_cls, monkeypatch, tmp_path):
+    """post_comment skips if a verdict comment already exists."""
+    # main() reads .blender-verdict.json from disk, so the test must create it.
+    verdict_file = tmp_path / ".blender-verdict.json"
+    verdict_file.write_text(
+        json.dumps(
+            {
+                "safe": False,
+                "confidence": "low",
+                "reason": "Breaking API change",
+                "breaking_changes": ["removed foo()"],
+                "affected_code": ["bar.py"],
+                "test_coverage": "none",
+            }
+        )
+    )
+
+    monkeypatch.setenv("PR_NUMBER", "10")
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.chdir(tmp_path)
+
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = [
+        _make_mock(Verdict.NEEDS_REVIEW.comment())
+    ]
+    pr.get_reviews.return_value = []
+    mock_gh_cls.return_value.get_repo.return_value.get_pull.return_value = pr
+
+    main()
+
+    pr.create_issue_comment.assert_not_called()
+
+
+@patch("scripts.post_major_review.Github")
+@patch("scripts.post_major_review.enable_auto_merge")
+def test_safe_verdict_approves_and_merges(mock_merge, mock_gh_cls, monkeypatch, tmp_path):
+    """Safe + high confidence verdict approves and enables auto-merge."""
+    # main() reads .blender-verdict.json from disk, so the test must create it.
+    verdict_file = tmp_path / ".blender-verdict.json"
+    verdict_file.write_text(
+        json.dumps(
+            {
+                "safe": True,
+                "confidence": "high",
+                "reason": "No breaking changes affect this codebase",
+                "breaking_changes": [],
+                "affected_code": [],
+                "test_coverage": "good",
+            }
+        )
+    )
+
+    monkeypatch.setenv("PR_NUMBER", "10")
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.chdir(tmp_path)
+
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = []
+    pr.get_reviews.return_value = []
+    mock_gh_cls.return_value.get_repo.return_value.get_pull.return_value = pr
+
+    main()
+
+    pr.create_review.assert_called_once()
+    mock_merge.assert_called_once_with(pr)
+    pr.create_issue_comment.assert_called_once()
+    comment_text = pr.create_issue_comment.call_args.args[0]
+    assert comment_text.startswith("SAFE:")


### PR DESCRIPTION
Each automerge run dispatched a new review for every open major-bump PR, regardless of prior verdicts. Verdict comments and "reviewing" comments were posted without dedup checks.

Add Verdict enum to github_utils as the single source of truth for comment prefixes. Move has_blender_verdict there so both automerge and post_major_review share the same check. Skip dispatch when a verdict already exists on the PR.