### PR TITLE
fix: use --raw-field for workflow dispatch to avoid path interpretation

### DIFF
--- a/.github/workflows/chore-automerge-dependabot-prs.yml
+++ b/.github/workflows/chore-automerge-dependabot-prs.yml
@@ -89,11 +89,11 @@ jobs:
             echo "Dispatching review for PR #${pr_number} (${dep_name} ${new_version})..."
             gh workflow run chore-review-major-dependabot-update.yml \
               --ref "$REF" \
-              --field target_repo="$TARGET_REPO" \
-              --field pr_number="$pr_number" \
-              --field dep_name="$dep_name" \
-              --field new_version="$new_version" \
-              --field dry_run="${DRY_RUN}"
+              --raw-field target_repo="$TARGET_REPO" \
+              --raw-field pr_number="$pr_number" \
+              --raw-field dep_name="$dep_name" \
+              --raw-field new_version="$new_version" \
+              --raw-field dry_run="${DRY_RUN}"
           done
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
gh's --field flag interprets values containing / as file paths. dep_name values like @vitejs/plugin-react caused dispatch failures. --raw-field passes values as literal strings.