### PR TITLE
fix: survive broken installs and chain fix to major review

### DIFF
--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -143,25 +143,13 @@ jobs:
         run: |
           PR_JSON=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
           PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
-
-          # Extract dep name, old version, new version from PR title
-          # "Bump python-ipware from 6.0.5 to 7.0.0"
-          DEP_NAME=$(echo "$PR_TITLE" | sed -n 's/.*[Bb]ump \(.*\) from .*/\1/p')
-          OLD_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*from \([^ ]*\) to .*/\1/p')
-          NEW_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*to \([^ ]*\)/\1/p')
+          export PR_TITLE
+          ${{ github.workspace }}/scripts/parse-pr-title.sh
 
           # Ecosystem from branch name
           BRANCH=$(echo "$PR_JSON" | jq -r '.head.ref')
           ECOSYSTEM=$(echo "$BRANCH" | cut -d/ -f2)
-
-          {
-            echo "dep_name=${DEP_NAME}"
-            echo "old_version=${OLD_VERSION}"
-            echo "new_version=${NEW_VERSION}"
-            echo "ecosystem=${ECOSYSTEM}"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "Dependency: ${DEP_NAME} ${OLD_VERSION} -> ${NEW_VERSION} (${ECOSYSTEM})"
+          echo "ecosystem=${ECOSYSTEM}" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: blender-fix-${{ inputs.target_repo }}-${{ inputs.pr_number }}
@@ -102,10 +103,12 @@ jobs:
           node-version: ${{ steps.config.outputs.node_version }}
 
       - name: Install dependencies
+        id: install
         if: steps.config.outputs.install_command != ''
+        continue-on-error: true
         working-directory: target
         run: |
-          eval "$INSTALL_COMMAND"
+          eval "$INSTALL_COMMAND" 2>&1 | tee /tmp/install-output.log
         env:
           INSTALL_COMMAND: ${{ steps.config.outputs.install_command }}
 
@@ -124,6 +127,8 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           REPO: ${{ inputs.target_repo }}
           PROMPT_TEMPLATE: .blender/fix-dependabot-prompt.md
+          INSTALL_FAILED: ${{ steps.install.outcome == 'failure' && 'true' || 'false' }}
+          INSTALL_LOG_FILE: /tmp/install-output.log
 
       - name: Comment on PR
         working-directory: target
@@ -146,9 +151,49 @@ jobs:
 
       # --- Commit (separate step, Claude is dead) ---
       - name: Commit and push fix
+        id: commit
         if: inputs.dry_run != 'true'
         working-directory: target
         run: ${{ github.workspace }}/scripts/commit.sh
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ inputs.target_repo }}
+
+      - name: Dispatch major-bump review
+        if: >-
+          inputs.dry_run != 'true'
+          && steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
+          TARGET_REPO: ${{ inputs.target_repo }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          PR_TITLE=$(gh api "repos/${TARGET_REPO}/pulls/${PR_NUMBER}" --jq '.title')
+
+          DEP_NAME=$(echo "$PR_TITLE" | sed -n 's/.*[Bb]ump \(.*\) from .*/\1/p')
+          OLD_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*from \([^ ]*\) to .*/\1/p')
+          NEW_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*to \([^ ]*\)/\1/p')
+
+          if [ -z "$OLD_VERSION" ] || [ -z "$NEW_VERSION" ]; then
+            echo "Could not parse versions from title: ${PR_TITLE}"
+            echo "Skipping — will be picked up by next sweep."
+            exit 0
+          fi
+
+          OLD_MAJOR="${OLD_VERSION%%.*}"
+          NEW_MAJOR="${NEW_VERSION%%.*}"
+
+          if [ "$OLD_MAJOR" = "$NEW_MAJOR" ]; then
+            echo "Not a major bump (${OLD_VERSION} -> ${NEW_VERSION}). Skipping."
+            exit 0
+          fi
+
+          echo "Major bump detected: ${DEP_NAME} ${OLD_VERSION} -> ${NEW_VERSION}"
+          gh workflow run chore-review-major-dependabot-update.yml \
+            --ref "$REF" \
+            --raw-field target_repo="$TARGET_REPO" \
+            --raw-field pr_number="$PR_NUMBER" \
+            --raw-field dep_name="$DEP_NAME" \
+            --raw-field new_version="$NEW_VERSION" \
+            --raw-field dry_run="false"

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -159,28 +159,35 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ inputs.target_repo }}
 
+      - name: Parse PR title
+        id: pr-meta
+        if: >-
+          inputs.dry_run != 'true'
+          && steps.commit.outputs.pushed == 'true'
+        run: |
+          PR_TITLE=$(gh api "repos/${TARGET_REPO}/pulls/${PR_NUMBER}" --jq '.title')
+          export PR_TITLE
+          ${{ github.workspace }}/scripts/parse-pr-title.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPO: ${{ inputs.target_repo }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+
       - name: Dispatch major-bump review
         if: >-
           inputs.dry_run != 'true'
           && steps.commit.outputs.pushed == 'true'
+          && steps.pr-meta.outputs.old_version != ''
+          && steps.pr-meta.outputs.new_version != ''
         env:
           GH_TOKEN: ${{ github.token }}
           REF: ${{ github.ref }}
           TARGET_REPO: ${{ inputs.target_repo }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          DEP_NAME: ${{ steps.pr-meta.outputs.dep_name }}
+          OLD_VERSION: ${{ steps.pr-meta.outputs.old_version }}
+          NEW_VERSION: ${{ steps.pr-meta.outputs.new_version }}
         run: |
-          PR_TITLE=$(gh api "repos/${TARGET_REPO}/pulls/${PR_NUMBER}" --jq '.title')
-
-          DEP_NAME=$(echo "$PR_TITLE" | sed -n 's/.*[Bb]ump \(.*\) from .*/\1/p')
-          OLD_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*from \([^ ]*\) to .*/\1/p')
-          NEW_VERSION=$(echo "$PR_TITLE" | sed -n 's/.*to \([^ ]*\)/\1/p')
-
-          if [ -z "$OLD_VERSION" ] || [ -z "$NEW_VERSION" ]; then
-            echo "Could not parse versions from title: ${PR_TITLE}"
-            echo "Skipping — will be picked up by next sweep."
-            exit 0
-          fi
-
           OLD_MAJOR="${OLD_VERSION%%.*}"
           NEW_MAJOR="${NEW_VERSION%%.*}"
 

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -26,6 +26,7 @@ fi
 
 if git diff --quiet && git diff --cached --quiet; then
   echo "No changes to commit."
+  echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
   exit 0
 fi
 
@@ -73,3 +74,4 @@ gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
   --field "sha=${COMMIT}"
 
 echo "Pushed verified commit ${COMMIT}"
+echo "pushed=true" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/scripts/gather-context.sh
+++ b/scripts/gather-context.sh
@@ -207,6 +207,15 @@ prompt="${prompt//\{\{DEP_NAME\}\}/$DEP_NAME}"
 prompt="${prompt//\{\{OLD_VERSION\}\}/$OLD_VERSION}"
 prompt="${prompt//\{\{NEW_VERSION\}\}/$NEW_VERSION}"
 
+# Optional install-error placeholder (fix mode with broken installs)
+install_error=""
+if [ "${INSTALL_FAILED:-}" = "true" ] && [ -n "${INSTALL_LOG_FILE:-}" ] && [ -f "${INSTALL_LOG_FILE}" ]; then
+  echo "Install failed — injecting last 200 lines of log into prompt."
+  raw_log=$(tail -200 "$INSTALL_LOG_FILE")
+  install_error=$(sanitize_for_prompt "$raw_log")
+fi
+prompt="${prompt//\{\{INSTALL_ERROR\}\}/$install_error}"
+
 # Write prompt to file for run-claude.sh
 echo "$prompt" > .blender-prompt
 

--- a/scripts/parse-pr-title.sh
+++ b/scripts/parse-pr-title.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# BLEnder parse-pr-title: extract dependency metadata from a Dependabot PR title.
+#
+# Reads: PR_TITLE (env var or stdin)
+# Writes to $GITHUB_OUTPUT: dep_name, old_version, new_version
+#
+# Titles like "Bump python-ipware from 6.0.5 to 7.0.0" are parsed.
+# Group titles ("Bump the eslint group...") won't match — outputs are empty.
+
+set -euo pipefail
+
+TITLE="${PR_TITLE:-$(cat)}"
+
+DEP_NAME=$(echo "$TITLE" | sed -n 's/.*[Bb]ump \(.*\) from .*/\1/p')
+OLD_VERSION=$(echo "$TITLE" | sed -n 's/.*from \([^ ]*\) to .*/\1/p')
+NEW_VERSION=$(echo "$TITLE" | sed -n 's/.*to \([^ ]*\)/\1/p')
+
+{
+  echo "dep_name=${DEP_NAME}"
+  echo "old_version=${OLD_VERSION}"
+  echo "new_version=${NEW_VERSION}"
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+echo "Parsed: ${DEP_NAME} ${OLD_VERSION} -> ${NEW_VERSION}"


### PR DESCRIPTION
The install step now uses continue-on-error with tee to capture output. gather-context injects the install log into {{INSTALL_ERROR}} so Claude can see and fix the problem. After a successful commit, the fix workflow parses the PR title for a major bump and dispatches the review workflow directly instead of waiting for the next sweep.