### PR TITLE
fix: survive auto-merge permission failures in post_major_review

### DIFF
--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -56,8 +56,10 @@ def has_blender_verdict(pr: PullRequest) -> bool:
     return False
 
 
-def enable_auto_merge(pr: PullRequest) -> None:
+def enable_auto_merge(pr: PullRequest) -> str | None:
     """Enable auto-merge on a PR via the GraphQL API.
+
+    Returns None on success, or an error message string on failure.
 
     The REST API merge endpoint requires elevated permissions that
     GITHUB_TOKEN in Actions doesn't have with branch protection.
@@ -78,5 +80,5 @@ def enable_auto_merge(pr: PullRequest) -> None:
     )
     errors = data.get("errors")
     if errors:
-        msg = "; ".join(e.get("message", str(e)) for e in errors)
-        raise RuntimeError(f"GraphQL enablePullRequestAutoMerge failed: {msg}")
+        return "; ".join(e.get("message", str(e)) for e in errors)
+    return None

--- a/scripts/post_major_review.py
+++ b/scripts/post_major_review.py
@@ -43,14 +43,18 @@ def post_comment(pr: PullRequest, body: str, dry_run: bool) -> None:
     pr.create_issue_comment(body)
 
 
-def approve_and_merge(pr: PullRequest, confidence: str, dry_run: bool) -> None:
-    """Approve the PR and enable auto-merge."""
+def approve_and_merge(pr: PullRequest, confidence: str, dry_run: bool) -> str | None:
+    """Approve the PR and enable auto-merge.
+
+    Returns None on success, or an error message if auto-merge failed.
+    The approval is posted regardless.
+    """
     review_body = Verdict.APPROVED.comment(f"({confidence} confidence).")
     if dry_run:
         print("DRY_RUN: would approve and enable auto-merge")
-        return
+        return None
     pr.create_review(event="APPROVE", body=review_body)
-    enable_auto_merge(pr)
+    return enable_auto_merge(pr)
 
 
 def main() -> None:
@@ -102,6 +106,21 @@ def main() -> None:
     print(f"Reason: {reason}")
 
     if safe and confidence != "low":
+        merge_err = approve_and_merge(pr, confidence, dry_run)
+        auto_merge_note = ""
+        if merge_err:
+            print(f"Warning: auto-merge failed: {merge_err}")
+            auto_merge_note = (
+                "\n\n> **Note:** auto-merge could not be enabled"
+                f" ({merge_err}).\n"
+                "> A maintainer can merge this PR manually, or"
+                " [enable auto-merge](https://docs.github.com/en/"
+                "repositories/configuring-branches-and-merges-in-"
+                "your-repository/configuring-pull-request-merges/"
+                "managing-auto-merge-for-pull-requests-in-your-"
+                "repository) on the repo so BLEnder can merge"
+                " safe updates in the future."
+            )
         comment = (
             f"{Verdict.SAFE.comment('to merge.')}\n\n"
             f"**Confidence:** {confidence}\n"
@@ -109,11 +128,14 @@ def main() -> None:
             f"**Breaking changes:** "
             f"{breaking_changes or 'None that affect this codebase'}\n"
             f"**Test coverage:** {test_coverage}"
+            f"{auto_merge_note}"
         )
-        approve_and_merge(pr, confidence, dry_run)
         post_comment(pr, comment, dry_run)
         if not dry_run:
-            print("Done. PR approved and auto-merge enabled.")
+            if merge_err:
+                print("Done. PR approved. Auto-merge not available.")
+            else:
+                print("Done. PR approved and auto-merge enabled.")
     else:
         comment = (
             f"{Verdict.NEEDS_REVIEW.comment()}\n\n"

--- a/tests/scripts/test_post_major_review.py
+++ b/tests/scripts/test_post_major_review.py
@@ -46,24 +46,26 @@ def test_no_duplicate_verdict_comment(mock_gh_cls, monkeypatch, tmp_path):
     pr.create_issue_comment.assert_not_called()
 
 
-@patch("scripts.post_major_review.Github")
-@patch("scripts.post_major_review.enable_auto_merge")
-def test_safe_verdict_approves_and_merges(mock_merge, mock_gh_cls, monkeypatch, tmp_path):
-    """Safe + high confidence verdict approves and enables auto-merge."""
-    # main() reads .blender-verdict.json from disk, so the test must create it.
-    verdict_file = tmp_path / ".blender-verdict.json"
-    verdict_file.write_text(
-        json.dumps(
-            {
-                "safe": True,
-                "confidence": "high",
-                "reason": "No breaking changes affect this codebase",
-                "breaking_changes": [],
-                "affected_code": [],
-                "test_coverage": "good",
-            }
-        )
+def _safe_verdict():
+    return json.dumps(
+        {
+            "safe": True,
+            "confidence": "high",
+            "reason": "No breaking changes affect this codebase",
+            "breaking_changes": [],
+            "affected_code": [],
+            "test_coverage": "good",
+        }
     )
+
+
+@patch("scripts.post_major_review.Github")
+@patch("scripts.post_major_review.enable_auto_merge", return_value=None)
+def test_safe_verdict_approves_and_merges(
+    mock_merge, mock_gh_cls, monkeypatch, tmp_path
+):
+    """Safe + high confidence verdict approves and enables auto-merge."""
+    (tmp_path / ".blender-verdict.json").write_text(_safe_verdict())
 
     monkeypatch.setenv("PR_NUMBER", "10")
     monkeypatch.setenv("REPO", "owner/repo")
@@ -83,3 +85,36 @@ def test_safe_verdict_approves_and_merges(mock_merge, mock_gh_cls, monkeypatch, 
     pr.create_issue_comment.assert_called_once()
     comment_text = pr.create_issue_comment.call_args.args[0]
     assert comment_text.startswith("SAFE:")
+    assert "auto-merge could not be enabled" not in comment_text
+
+
+@patch("scripts.post_major_review.Github")
+@patch(
+    "scripts.post_major_review.enable_auto_merge",
+    return_value="Resource not accessible by integration",
+)
+def test_safe_verdict_posts_comment_when_automerge_fails(
+    mock_merge, mock_gh_cls, monkeypatch, tmp_path
+):
+    """Auto-merge failure still approves and posts a comment with a note."""
+    (tmp_path / ".blender-verdict.json").write_text(_safe_verdict())
+
+    monkeypatch.setenv("PR_NUMBER", "10")
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+    monkeypatch.chdir(tmp_path)
+
+    pr = MagicMock()
+    pr.get_issue_comments.return_value = []
+    pr.get_reviews.return_value = []
+    mock_gh_cls.return_value.get_repo.return_value.get_pull.return_value = pr
+
+    main()
+
+    pr.create_review.assert_called_once()
+    pr.create_issue_comment.assert_called_once()
+    comment_text = pr.create_issue_comment.call_args.args[0]
+    assert comment_text.startswith("SAFE:")
+    assert "auto-merge could not be enabled" in comment_text
+    assert "enable auto-merge" in comment_text


### PR DESCRIPTION
enable_auto_merge now returns an error string instead of raising. When the target repo lacks auto-merge permissions, BLEnder still approves the PR and posts its safety analysis. The comment includes a note telling repo owners how to enable auto-merge.

Fixes crash on repos like mozilla/blurts-server where the GitHub App token cannot call enablePullRequestAutoMerge.