### PR TITLE
fix: correct BOT_LOGIN to match actual GitHub App login

### DIFF
--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -7,7 +7,7 @@ from enum import Enum
 from github.PullRequest import PullRequest
 
 
-BOT_LOGIN = "blender[bot]"
+BOT_LOGIN = "mozilla-blender[bot]"
 
 
 class Verdict(Enum):

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -356,7 +356,7 @@ def test_main_no_comment_when_review_major(mock_process, monkeypatch):
 # --- has_blender_verdict ---
 
 
-def _gh_comment(body: str, login: str = "blender[bot]"):
+def _gh_comment(body: str, login: str = "mozilla-blender[bot]"):
     """Build a mock GitHub comment/review object with .body and .user.login."""
     m = MagicMock()
     m.body = body


### PR DESCRIPTION
BOT_LOGIN was "blender[bot]" but the app's actual login is "mozilla-blender[bot]". This broke has_blender_verdict() — it never matched its own comments. The automerge workflow dispatched the major-bump review on every sweep cycle, flooding PRs with duplicate verdict comments.