### PR TITLE
fix: deduplicate @dependabot recreate comments

### DIFF
--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -678,6 +678,18 @@ def _post_dependabot_recreate(pr: PullRequest, dry_run: bool) -> None:
     if dry_run:
         print(f"  DRY_RUN: would comment @dependabot recreate on PR #{pr.number}")
         return
+
+    for c in pr.get_issue_comments():
+        if c.user.login == BOT_LOGIN and c.body == "@dependabot recreate":
+            print(f"  Already posted @dependabot recreate on PR #{pr.number}")
+            return
+        if (
+            c.user.login == "dependabot[bot]"
+            and "only users with push access" in c.body
+        ):
+            print(f"  Dependabot rejected recreate on PR #{pr.number}, skipping")
+            return
+
     pr.create_issue_comment("@dependabot recreate")
     print(f"  Posted @dependabot recreate on PR #{pr.number}")
 

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -188,8 +188,33 @@ def test_post_dependabot_recreate_comment_text():
     """Exact text matters — Dependabot parses commands literally."""
     pr = MagicMock()
     pr.number = 42
+    pr.get_issue_comments.return_value = []
     _post_dependabot_recreate(pr, dry_run=False)
     pr.create_issue_comment.assert_called_once_with("@dependabot recreate")
+
+
+def test_post_dependabot_recreate_skips_when_already_posted():
+    """Don't post a second @dependabot recreate on the same PR."""
+    pr = MagicMock()
+    pr.number = 42
+    existing = MagicMock()
+    existing.user.login = "mozilla-blender[bot]"
+    existing.body = "@dependabot recreate"
+    pr.get_issue_comments.return_value = [existing]
+    _post_dependabot_recreate(pr, dry_run=False)
+    pr.create_issue_comment.assert_not_called()
+
+
+def test_post_dependabot_recreate_skips_when_rejected():
+    """Don't retry recreate after dependabot says we lack push access."""
+    pr = MagicMock()
+    pr.number = 42
+    rejection = MagicMock()
+    rejection.user.login = "dependabot[bot]"
+    rejection.body = "Sorry, only users with push access can use that command."
+    pr.get_issue_comments.return_value = [rejection]
+    _post_dependabot_recreate(pr, dry_run=False)
+    pr.create_issue_comment.assert_not_called()
 
 
 # --- main loop: advisory skip triggers recreate, regular skip does not ---


### PR DESCRIPTION
_post_dependabot_recreate posted blindly every sweep run. When dependabot rejected the command (no push access), BLEnder looped: 50+ identical comments on mozilla/blurts-server#6582.

Check existing comments before posting. Skip if BLEnder already posted @dependabot recreate, or if dependabot responded with a rejection.