### PR TITLE
fix: coordinate sweep and fix workflows to avoid double comments and missed retries

### DIFF
--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -204,3 +204,18 @@ jobs:
             --raw-field dep_name="$DEP_NAME" \
             --raw-field new_version="$NEW_VERSION" \
             --raw-field dry_run="false"
+
+      - name: Comment if fix failed
+        if: >-
+          always()
+          && inputs.dry_run != 'true'
+          && steps.commit.outputs.pushed != 'true'
+        working-directory: target
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --body "BLEnder could not fix this PR automatically. [Workflow run](${RUN_URL})"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          RUN_URL: >-
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -48,6 +48,10 @@ class AdvisorySkipPR(SkipPR):
     """Skip caused by a GHSA advisory on the new version."""
 
 
+class CIFailurePR(SkipPR):
+    """CI failures are handled by the fix workflow; suppress the comment."""
+
+
 class MajorBumpPR(SkipPR):
     """Skip caused by a major version bump. Carries dep/meta for dispatch."""
 
@@ -350,7 +354,7 @@ def gate_ci(repo: Repository, sha: str) -> None:
             pending += 1
 
     if failing > 0:
-        raise SkipPR(f"CI has {failing} failure(s)")
+        raise CIFailurePR(f"CI has {failing} failure(s)")
     if pending > 0:
         raise SkipPR(f"CI has {pending} pending check(s)")
 
@@ -781,6 +785,12 @@ def main() -> None:
                 )
             else:
                 _post_skip_comment(pr, str(e), False, config.dry_run)
+
+        except CIFailurePR as e:
+            print(f"  SKIP (CI failure, fix workflow handles it): {e}")
+            skipped += 1
+            pkg = _package_name_from_branch(pr.head.ref)
+            skip_reasons.append(f"#{pr.number} ({pkg}): {e}")
 
         except SkipPR as e:
             is_retry = isinstance(e, RetryPR)

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -141,21 +141,28 @@ def process_repo(repo: Repository) -> list[Action]:
                 print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
                 continue
 
-            # Check for any BLEnder comment (covers fix attempts AND
-            # automerge skip/reject decisions like "will not auto-merge")
-            comments = pr.get_issue_comments()
-            blender_comment = next(
-                (
-                    c.body
-                    for c in comments
-                    if c.user.login.endswith("[bot]")
-                    and (c.body or "").startswith("BLEnder")
-                ),
-                None,
+            # Only skip if a fix-related comment was posted AFTER the
+            # latest commit.  Stale comments (before a force-push) are
+            # ignored so the fix can be retried on new code.
+            latest_commit_date = max(
+                (c.commit.committer.date for c in commits), default=None
             )
-            if blender_comment:
-                print(f"    PR #{pr.number}: BLEnder already commented, skipping")
-                continue
+            if latest_commit_date is not None:
+                fix_comments = [
+                    c
+                    for c in pr.get_issue_comments()
+                    if c.user.login.endswith("[bot]")
+                    and (
+                        (c.body or "").startswith("BLEnder picked up")
+                        or (c.body or "").startswith("BLEnder could not fix")
+                    )
+                ]
+                fresh_fix_comment = any(
+                    c.created_at >= latest_commit_date for c in fix_comments
+                )
+                if fresh_fix_comment:
+                    print(f"    PR #{pr.number}: fresh BLEnder fix comment, skipping")
+                    continue
 
         print(f"    PR #{pr.number}: {result}")
         actions.append(

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -132,7 +132,9 @@ def process_repo(repo: Repository) -> list[Action]:
             continue
 
         if result == "fix":
-            # Check for BLEnder commits on the PR
+            # Check for BLEnder commits on the PR.
+            # Only bot commits with the "BLEnder fix(" prefix count.
+            # Human commits use different messages and don't block dispatch.
             commits = pr.get_commits()
             has_blender_commit = any(
                 (c.commit.message or "").startswith("BLEnder fix(") for c in commits
@@ -141,9 +143,10 @@ def process_repo(repo: Repository) -> list[Action]:
                 print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
                 continue
 
-            # Only skip if a fix-related comment was posted AFTER the
-            # latest commit.  Stale comments (before a force-push) are
-            # ignored so the fix can be retried on new code.
+            # Only skip if a bot fix-related comment was posted AFTER the
+            # latest commit.  Human comments are ignored (login must end
+            # with "[bot]").  Stale comments (before a force-push) are
+            # also ignored so the fix can be retried on new code.
             latest_commit_date = max(
                 (c.commit.committer.date for c in commits), default=None
             )

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -220,6 +220,43 @@ def test_post_dependabot_recreate_skips_when_rejected():
     pr.create_issue_comment.assert_not_called()
 
 
+# --- Helpers for main-loop tests ---
+
+
+def _make_dependabot_pr(
+    number: int = 42,
+    ref: str = "dependabot/npm_and_yarn/lodash-4.17.21",
+    comments: list | None = None,
+    reviews: list | None = None,
+):
+    """Build a mock dependabot PR for main-loop tests."""
+    pr = MagicMock()
+    pr.number = number
+    pr.title = "Bump something"
+    pr.user.login = "dependabot[bot]"
+    pr.head.ref = ref
+    pr.get_issue_comments.return_value = comments or []
+    pr.get_reviews.return_value = reviews or []
+    return pr
+
+
+def _run_main(monkeypatch, pr, process_side_effect, extra_env=None):
+    """Set up env, mock process_pr, run main(), return the mock PR."""
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+    for k, v in (extra_env or {}).items():
+        monkeypatch.setenv(k, v)
+
+    with (
+        patch("scripts.automerge_dependabot.process_pr") as mock_process,
+        patch("scripts.automerge_dependabot.Github") as gh_cls,
+    ):
+        mock_process.side_effect = process_side_effect
+        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
+        main()
+
+
 # --- main loop: advisory skip triggers recreate, regular skip does not ---
 
 
@@ -230,28 +267,13 @@ def test_post_dependabot_recreate_skips_when_rejected():
         (SkipPR("major version bump"), False),
     ],
 )
-@patch("scripts.automerge_dependabot.process_pr")
 def test_main_loop_recreate_on_advisory_skip_only(
-    mock_process,
     exception,
     expect_recreate,
     monkeypatch,
 ):
-    monkeypatch.setenv("REPO", "owner/repo")
-    monkeypatch.setenv("GH_TOKEN", "fake-token")
-    monkeypatch.setenv("DRY_RUN", "false")
-
-    pr = MagicMock()
-    pr.number = 7
-    pr.user.login = "dependabot[bot]"
-    pr.head.ref = "dependabot/npm_and_yarn/lodash-4.17.21"
-    pr.get_issue_comments.return_value = []
-
-    mock_process.side_effect = exception
-
-    with patch("scripts.automerge_dependabot.Github") as gh_cls:
-        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
-        main()
+    pr = _make_dependabot_pr(number=7)
+    _run_main(monkeypatch, pr, exception)
 
     recreate_calls = [
         c
@@ -285,50 +307,37 @@ def test_gate_versions_raises_major_bump_pr():
     assert exc_info.value.meta is meta
 
 
-@patch("scripts.automerge_dependabot.process_pr")
-def test_main_outputs_major_bumps_json(mock_process, monkeypatch, tmp_path):
-    """MajorBumpPR exceptions are collected and written to GITHUB_OUTPUT."""
-    monkeypatch.setenv("REPO", "owner/repo")
-    monkeypatch.setenv("GH_TOKEN", "fake-token")
-    monkeypatch.setenv("DRY_RUN", "false")
-    monkeypatch.setenv("REVIEW_MAJOR", "true")
-
-    output_file = tmp_path / "github_output"
-    output_file.write_text("")
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-
+def _major_bump_exception(dep_name="ipware", old="6.0.5", new="7.0.0", **meta_kw):
+    """Build a MajorBumpPR exception with sensible defaults."""
     dep = DependencyUpdate(
-        name="ipware",
-        version="7.0.0",
+        name=dep_name,
+        version=new,
         dependency_type="direct:production",
         update_type="version-update:semver-major",
-        old_version="6.0.5",
+        old_version=old,
     )
     meta = PRMetadata(
         dependencies=[dep],
         has_major=True,
-        ecosystem="pip",
-        raw_ecosystem="pip",
-        old_version="6.0.5",
-        new_version="7.0.0",
+        old_version=old,
+        new_version=new,
+        **meta_kw,
     )
-    mock_process.side_effect = MajorBumpPR(
-        "major version bump on ipware",
-        dep=dep,
-        meta=meta,
+    return MajorBumpPR(f"major version bump on {dep_name}", dep=dep, meta=meta)
+
+
+def test_main_outputs_major_bumps_json(monkeypatch, tmp_path):
+    """MajorBumpPR exceptions are collected and written to GITHUB_OUTPUT."""
+    output_file = tmp_path / "github_output"
+    output_file.write_text("")
+
+    pr = _make_dependabot_pr(number=42, ref="dependabot/pip/ipware-7.0.0")
+    _run_main(
+        monkeypatch,
+        pr,
+        _major_bump_exception(ecosystem="pip", raw_ecosystem="pip"),
+        extra_env={"REVIEW_MAJOR": "true", "GITHUB_OUTPUT": str(output_file)},
     )
-
-    pr = MagicMock()
-    pr.number = 42
-    pr.title = "Bump ipware from 6.0.5 to 7.0.0"
-    pr.user.login = "dependabot[bot]"
-    pr.head.ref = "dependabot/pip/ipware-7.0.0"
-    pr.get_issue_comments.return_value = []
-    pr.get_reviews.return_value = []
-
-    with patch("scripts.automerge_dependabot.Github") as gh_cls:
-        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
-        main()
 
     output = output_file.read_text()
     assert "major_bumps=" in output
@@ -338,39 +347,15 @@ def test_main_outputs_major_bumps_json(mock_process, monkeypatch, tmp_path):
     assert bumps[0]["dep_name"] == "ipware"
 
 
-@patch("scripts.automerge_dependabot.process_pr")
-def test_main_no_comment_when_review_major(mock_process, monkeypatch):
+def test_main_no_comment_when_review_major(monkeypatch):
     """When REVIEW_MAJOR=true, MajorBumpPR posts no comment (workflow handles it)."""
-    monkeypatch.setenv("REPO", "owner/repo")
-    monkeypatch.setenv("GH_TOKEN", "fake-token")
-    monkeypatch.setenv("DRY_RUN", "false")
-    monkeypatch.setenv("REVIEW_MAJOR", "true")
-
-    dep = DependencyUpdate(
-        name="ipware",
-        version="7.0.0",
-        dependency_type="direct:production",
-        update_type="version-update:semver-major",
+    pr = _make_dependabot_pr(number=42, ref="dependabot/pip/ipware-7.0.0")
+    _run_main(
+        monkeypatch,
+        pr,
+        _major_bump_exception(),
+        extra_env={"REVIEW_MAJOR": "true"},
     )
-    meta = PRMetadata(dependencies=[dep], has_major=True)
-    mock_process.side_effect = MajorBumpPR(
-        "major version bump on ipware",
-        dep=dep,
-        meta=meta,
-    )
-
-    pr = MagicMock()
-    pr.number = 42
-    pr.title = "Bump ipware from 6.0.5 to 7.0.0"
-    pr.user.login = "dependabot[bot]"
-    pr.head.ref = "dependabot/pip/ipware-7.0.0"
-    pr.get_issue_comments.return_value = []
-    pr.get_reviews.return_value = []
-
-    with patch("scripts.automerge_dependabot.Github") as gh_cls:
-        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
-        main()
-
     pr.create_issue_comment.assert_not_called()
 
 
@@ -423,53 +408,25 @@ def test_has_blender_verdict_ignores_human_comments():
     assert has_blender_verdict(pr) is False
 
 
-@patch("scripts.automerge_dependabot.process_pr")
-def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tmp_path):
+def test_main_skips_dispatch_when_already_reviewed(monkeypatch, tmp_path):
     """Already-reviewed major bumps are not dispatched again."""
-    monkeypatch.setenv("REPO", "owner/repo")
-    monkeypatch.setenv("GH_TOKEN", "fake-token")
-    monkeypatch.setenv("DRY_RUN", "false")
-    monkeypatch.setenv("REVIEW_MAJOR", "true")
-
     output_file = tmp_path / "github_output"
     output_file.write_text("")
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
 
-    dep = DependencyUpdate(
-        name="ipware",
-        version="7.0.0",
-        dependency_type="direct:production",
-        update_type="version-update:semver-major",
-        old_version="6.0.5",
+    pr = _make_dependabot_pr(
+        number=42,
+        ref="dependabot/pip/ipware-7.0.0",
+        comments=[
+            _gh_comment(body=Verdict.NO_VERDICT.comment("Manual review needed."))
+        ],
     )
-    meta = PRMetadata(
-        dependencies=[dep],
-        has_major=True,
-        ecosystem="pip",
-        raw_ecosystem="pip",
-        old_version="6.0.5",
-        new_version="7.0.0",
-    )
-    mock_process.side_effect = MajorBumpPR(
-        "major version bump on ipware", dep=dep, meta=meta
+    _run_main(
+        monkeypatch,
+        pr,
+        _major_bump_exception(ecosystem="pip", raw_ecosystem="pip"),
+        extra_env={"REVIEW_MAJOR": "true", "GITHUB_OUTPUT": str(output_file)},
     )
 
-    pr = MagicMock()
-    pr.number = 42
-    pr.title = "Bump ipware from 6.0.5 to 7.0.0"
-    pr.user.login = "dependabot[bot]"
-    pr.head.ref = "dependabot/pip/ipware-7.0.0"
-    # Simulate existing verdict comment
-    pr.get_issue_comments.return_value = [
-        _gh_comment(body=Verdict.NO_VERDICT.comment("Manual review needed."))
-    ]
-    pr.get_reviews.return_value = []
-
-    with patch("scripts.automerge_dependabot.Github") as gh_cls:
-        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
-        main()
-
-    # No major_bumps output written
     output = output_file.read_text()
     assert "major_bumps=" not in output
 
@@ -477,22 +434,8 @@ def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tm
 # --- CIFailurePR: no comment posted ---
 
 
-@patch("scripts.automerge_dependabot.process_pr")
-def test_main_no_comment_on_ci_failure(mock_process, monkeypatch):
+def test_main_no_comment_on_ci_failure(monkeypatch):
     """CIFailurePR skips without posting a comment."""
-    monkeypatch.setenv("REPO", "owner/repo")
-    monkeypatch.setenv("GH_TOKEN", "fake-token")
-    monkeypatch.setenv("DRY_RUN", "false")
-
-    mock_process.side_effect = CIFailurePR("CI has 1 failure(s)")
-
-    pr = MagicMock()
-    pr.number = 99
-    pr.user.login = "dependabot[bot]"
-    pr.head.ref = "dependabot/npm_and_yarn/lodash-4.17.21"
-
-    with patch("scripts.automerge_dependabot.Github") as gh_cls:
-        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
-        main()
-
+    pr = _make_dependabot_pr(number=99)
+    _run_main(monkeypatch, pr, CIFailurePR("CI has 1 failure(s)"))
     pr.create_issue_comment.assert_not_called()

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from scripts.automerge_dependabot import (
     _post_dependabot_recreate,
     gate_advisories,
     gate_versions,
+    main,
     version_in_range,
 )
 from scripts.github_utils import Verdict, has_blender_verdict
@@ -235,8 +237,6 @@ def test_main_loop_recreate_on_advisory_skip_only(
     expect_recreate,
     monkeypatch,
 ):
-    from scripts.automerge_dependabot import main
-
     monkeypatch.setenv("REPO", "owner/repo")
     monkeypatch.setenv("GH_TOKEN", "fake-token")
     monkeypatch.setenv("DRY_RUN", "false")
@@ -288,9 +288,6 @@ def test_gate_versions_raises_major_bump_pr():
 @patch("scripts.automerge_dependabot.process_pr")
 def test_main_outputs_major_bumps_json(mock_process, monkeypatch, tmp_path):
     """MajorBumpPR exceptions are collected and written to GITHUB_OUTPUT."""
-    import json
-    from scripts.automerge_dependabot import main
-
     monkeypatch.setenv("REPO", "owner/repo")
     monkeypatch.setenv("GH_TOKEN", "fake-token")
     monkeypatch.setenv("DRY_RUN", "false")
@@ -344,8 +341,6 @@ def test_main_outputs_major_bumps_json(mock_process, monkeypatch, tmp_path):
 @patch("scripts.automerge_dependabot.process_pr")
 def test_main_no_comment_when_review_major(mock_process, monkeypatch):
     """When REVIEW_MAJOR=true, MajorBumpPR posts no comment (workflow handles it)."""
-    from scripts.automerge_dependabot import main
-
     monkeypatch.setenv("REPO", "owner/repo")
     monkeypatch.setenv("GH_TOKEN", "fake-token")
     monkeypatch.setenv("DRY_RUN", "false")
@@ -431,8 +426,6 @@ def test_has_blender_verdict_ignores_human_comments():
 @patch("scripts.automerge_dependabot.process_pr")
 def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tmp_path):
     """Already-reviewed major bumps are not dispatched again."""
-    from scripts.automerge_dependabot import main
-
     monkeypatch.setenv("REPO", "owner/repo")
     monkeypatch.setenv("GH_TOKEN", "fake-token")
     monkeypatch.setenv("DRY_RUN", "false")
@@ -486,9 +479,7 @@ def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tm
 
 @patch("scripts.automerge_dependabot.process_pr")
 def test_main_no_comment_on_ci_failure(mock_process, monkeypatch):
-    """#16: CIFailurePR skips without posting a comment."""
-    from scripts.automerge_dependabot import main
-
+    """CIFailurePR skips without posting a comment."""
     monkeypatch.setenv("REPO", "owner/repo")
     monkeypatch.setenv("GH_TOKEN", "fake-token")
     monkeypatch.setenv("DRY_RUN", "false")

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -8,6 +8,7 @@ import pytest
 
 from scripts.automerge_dependabot import (
     AdvisorySkipPR,
+    CIFailurePR,
     DependencyUpdate,
     MajorBumpPR,
     PRMetadata,
@@ -478,3 +479,29 @@ def test_main_skips_dispatch_when_already_reviewed(mock_process, monkeypatch, tm
     # No major_bumps output written
     output = output_file.read_text()
     assert "major_bumps=" not in output
+
+
+# --- CIFailurePR: no comment posted ---
+
+
+@patch("scripts.automerge_dependabot.process_pr")
+def test_main_no_comment_on_ci_failure(mock_process, monkeypatch):
+    """#16: CIFailurePR skips without posting a comment."""
+    from scripts.automerge_dependabot import main
+
+    monkeypatch.setenv("REPO", "owner/repo")
+    monkeypatch.setenv("GH_TOKEN", "fake-token")
+    monkeypatch.setenv("DRY_RUN", "false")
+
+    mock_process.side_effect = CIFailurePR("CI has 1 failure(s)")
+
+    pr = MagicMock()
+    pr.number = 99
+    pr.user.login = "dependabot[bot]"
+    pr.head.ref = "dependabot/npm_and_yarn/lodash-4.17.21"
+
+    with patch("scripts.automerge_dependabot.Github") as gh_cls:
+        gh_cls.return_value.get_repo.return_value.get_pulls.return_value = [pr]
+        main()
+
+    pr.create_issue_comment.assert_not_called()

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import pytest
-
 from scripts.sweep import process_repo
 
 # --- Shared timestamps ---

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -9,21 +9,29 @@ import pytest
 
 from scripts.sweep import process_repo
 
+# --- Shared timestamps ---
 
-def _make_commit(message: str, date: datetime | None = None):
+T_EARLY = datetime(2025, 1, 1, tzinfo=timezone.utc)
+T_LATE = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+
+# --- Mock builders ---
+
+
+def _make_commit(message: str, date: datetime = T_EARLY):
     """Build a mock commit object."""
     c = MagicMock()
     c.commit.message = message
-    c.commit.committer.date = date or datetime(2025, 1, 1, tzinfo=timezone.utc)
+    c.commit.committer.date = date
     return c
 
 
-def _make_comment(login: str, body: str, created_at: datetime | None = None):
+def _make_comment(login: str, body: str, created_at: datetime = T_EARLY):
     """Build a mock issue comment."""
     c = MagicMock()
     c.user.login = login
     c.body = body
-    c.created_at = created_at or datetime(2025, 1, 1, tzinfo=timezone.utc)
+    c.created_at = created_at
     return c
 
 
@@ -41,40 +49,28 @@ def _make_pr(
     """
     pr = MagicMock()
     pr.number = number
-    pr.title = f"Bump foo from 1.0.0 to 2.0.0"
+    pr.title = "Bump foo from 1.0.0 to 2.0.0"
     pr.user.login = "dependabot[bot]" if is_dependabot else "octocat"
     type(pr.head).sha = PropertyMock(return_value="abc123")
 
-    # Commits
     commit_list = list(commits or [])
     if blender_commit:
-        commit_list.append(
-            _make_commit(
-                "BLEnder fix(foo): update lockfile",
-                datetime(2025, 1, 2, tzinfo=timezone.utc),
-            )
-        )
+        commit_list.append(_make_commit("BLEnder fix(foo): update lockfile", T_LATE))
     if not commit_list:
         commit_list.append(_make_commit("Bump foo from 1.0.0 to 2.0.0"))
     pr.get_commits.return_value = commit_list
-
-    # Comments
     pr.get_issue_comments.return_value = list(comments or [])
 
     return pr, ci_status
 
 
-def _build_repo(prs: list[tuple[MagicMock, str]]):
-    """Build a mock repo with .blender config and given PRs."""
+def _run_sweep(prs: list[tuple[MagicMock, str]]) -> list:
+    """Build a mock repo, patch check_pr_status, and run process_repo."""
     repo = MagicMock()
     repo.full_name = "owner/repo"
-    # has_blender_config returns True
     repo.get_contents.return_value = True
+    repo.get_pulls.return_value = [pr for pr, _ in prs]
 
-    pr_objects = [pr for pr, _ in prs]
-    repo.get_pulls.return_value = pr_objects
-
-    # Patch check_pr_status to return the configured status
     status_map = {pr.number: status for pr, status in prs}
 
     def mock_check_pr_status(_repo, pr):
@@ -83,10 +79,10 @@ def _build_repo(prs: list[tuple[MagicMock, str]]):
             return "automerge"
         elif s == "failing":
             return "fix"
-        else:
-            return None
+        return None
 
-    return repo, mock_check_pr_status
+    with patch("scripts.sweep.check_pr_status", side_effect=mock_check_pr_status):
+        return process_repo(repo)
 
 
 # --- CI-failing PRs (result == "fix") ---
@@ -94,102 +90,78 @@ def _build_repo(prs: list[tuple[MagicMock, str]]):
 
 class TestFixDispatch:
     def test_fresh_pr_dispatches_fix(self):
-        """#1: No BLEnder activity -> dispatch fix."""
-        pr, status = _make_pr(1, "failing")
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        """No BLEnder activity -> dispatch fix."""
+        actions = _run_sweep([_make_pr(1, "failing")])
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
     def test_blender_commit_skips(self):
-        """#2: BLEnder commit exists -> skip."""
-        pr, status = _make_pr(2, "failing", blender_commit=True)
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        """BLEnder commit exists -> skip."""
+        actions = _run_sweep([_make_pr(2, "failing", blender_commit=True)])
         assert actions == []
 
     def test_fresh_picked_up_comment_skips(self):
-        """#3: Fresh 'picked up' comment -> skip."""
-        commit_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        comment_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        """Fresh 'picked up' comment -> skip."""
         pr, status = _make_pr(
             3,
             "failing",
-            commits=[_make_commit("Bump foo", commit_date)],
+            commits=[_make_commit("Bump foo", T_EARLY)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_LATE)
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
-        assert actions == []
+        assert _run_sweep([(pr, status)]) == []
 
     def test_stale_picked_up_comment_dispatches(self):
-        """#4: Stale 'picked up' comment (before force-push) -> dispatch fix."""
-        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        """Stale 'picked up' comment (before force-push) -> dispatch fix."""
         pr, status = _make_pr(
             4,
             "failing",
-            commits=[_make_commit("Bump foo", commit_date)],
+            commits=[_make_commit("Bump foo", T_LATE)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_EARLY)
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
     def test_fresh_could_not_fix_skips(self):
-        """#5: Fresh 'could not fix' comment -> skip."""
-        commit_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        comment_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        """Fresh 'could not fix' comment -> skip."""
         pr, status = _make_pr(
             5,
             "failing",
-            commits=[_make_commit("Bump foo", commit_date)],
+            commits=[_make_commit("Bump foo", T_EARLY)],
             comments=[
                 _make_comment(
                     "blender[bot]",
                     "BLEnder could not fix this PR automatically.",
-                    comment_date,
+                    T_LATE,
                 )
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
-        assert actions == []
+        assert _run_sweep([(pr, status)]) == []
 
     def test_stale_could_not_fix_dispatches(self):
-        """#6: Stale 'could not fix' comment -> dispatch fix."""
-        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        """Stale 'could not fix' comment -> dispatch fix."""
         pr, status = _make_pr(
             6,
             "failing",
-            commits=[_make_commit("Bump foo", commit_date)],
+            commits=[_make_commit("Bump foo", T_LATE)],
             comments=[
                 _make_comment(
                     "blender[bot]",
                     "BLEnder could not fix this PR automatically.",
-                    comment_date,
+                    T_EARLY,
                 )
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
     def test_automerge_comment_does_not_block_fix(self):
-        """#7: 'will not auto-merge' comment only -> dispatch fix."""
+        """'will not auto-merge' comment only -> dispatch fix."""
         pr, status = _make_pr(
             7,
             "failing",
@@ -197,18 +169,16 @@ class TestFixDispatch:
                 _make_comment(
                     "blender[bot]",
                     "BLEnder: will not auto-merge (CI has 1 failure(s)).",
-                    datetime(2025, 1, 2, tzinfo=timezone.utc),
+                    T_LATE,
                 )
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
     def test_retry_comment_does_not_block_fix(self):
-        """#8: 'skipped (...). Will retry' comment only -> dispatch fix."""
+        """'skipped (...). Will retry' comment only -> dispatch fix."""
         pr, status = _make_pr(
             8,
             "failing",
@@ -216,33 +186,26 @@ class TestFixDispatch:
                 _make_comment(
                     "blender[bot]",
                     "BLEnder: skipped (score unknown). Will retry on next scheduled run.",
-                    datetime(2025, 1, 2, tzinfo=timezone.utc),
+                    T_LATE,
                 )
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
     def test_blender_commit_takes_precedence_over_stale_comment(self):
-        """#9: BLEnder commit + stale comment -> skip (commit wins)."""
-        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        """BLEnder commit + stale comment -> skip (commit wins)."""
         pr, status = _make_pr(
             9,
             "failing",
             blender_commit=True,
-            commits=[_make_commit("Bump foo", commit_date)],
+            commits=[_make_commit("Bump foo", T_LATE)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_EARLY)
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
-        assert actions == []
+        assert _run_sweep([(pr, status)]) == []
 
 
 # --- CI-passing PRs (result == "automerge") ---
@@ -250,30 +213,21 @@ class TestFixDispatch:
 
 class TestAutomergeDispatch:
     def test_passing_pr_dispatches_automerge(self):
-        """#10: No activity -> dispatch automerge."""
-        pr, status = _make_pr(10, "passing")
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        """No activity -> dispatch automerge."""
+        actions = _run_sweep([_make_pr(10, "passing")])
         assert len(actions) == 1
         assert actions[0].action == "automerge"
 
     def test_blender_comments_do_not_block_automerge(self):
-        """#11: BLEnder comments don't block automerge dispatch."""
+        """BLEnder comments don't block automerge dispatch."""
         pr, status = _make_pr(
             11,
             "passing",
             comments=[
-                _make_comment(
-                    "blender[bot]",
-                    "BLEnder picked up this PR.",
-                    datetime(2025, 1, 2, tzinfo=timezone.utc),
-                )
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_LATE)
             ],
         )
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
+        actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "automerge"
 
@@ -283,12 +237,8 @@ class TestAutomergeDispatch:
 
 class TestPendingPR:
     def test_pending_pr_skipped(self):
-        """#12: Pending checks -> skip."""
-        pr, status = _make_pr(12, "pending")
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
-        assert actions == []
+        """Pending checks -> skip."""
+        assert _run_sweep([_make_pr(12, "pending")]) == []
 
 
 # --- Edge cases ---
@@ -296,24 +246,19 @@ class TestPendingPR:
 
 class TestEdgeCases:
     def test_non_dependabot_pr_skipped(self):
-        """#13: Non-dependabot PR -> not in the list at all."""
-        pr, status = _make_pr(13, "failing", is_dependabot=False)
-        repo, checker = _build_repo([(pr, status)])
-        with patch("scripts.sweep.check_pr_status", side_effect=checker):
-            actions = process_repo(repo)
-        assert actions == []
+        """Non-dependabot PR -> not in the list at all."""
+        assert _run_sweep([_make_pr(13, "failing", is_dependabot=False)]) == []
 
     def test_no_blender_config_skips(self):
-        """#14: No .blender config -> skip repo."""
+        """No .blender config -> skip repo."""
         from github.GithubException import UnknownObjectException
 
         repo = MagicMock()
         repo.get_contents.side_effect = UnknownObjectException(404, {}, {})
-        actions = process_repo(repo)
-        assert actions == []
+        assert process_repo(repo) == []
 
     def test_check_pr_status_exception_continues(self):
-        """#15: Exception in check_pr_status -> skip PR, don't crash."""
+        """Exception in check_pr_status -> skip PR, don't crash."""
         pr, _ = _make_pr(15, "failing")
         repo = MagicMock()
         repo.full_name = "owner/repo"
@@ -323,5 +268,4 @@ class TestEdgeCases:
         with patch(
             "scripts.sweep.check_pr_status", side_effect=RuntimeError("API error")
         ):
-            actions = process_repo(repo)
-        assert actions == []
+            assert process_repo(repo) == []

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -1,0 +1,327 @@
+"""Tests for scripts.sweep.process_repo."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from scripts.sweep import process_repo
+
+
+def _make_commit(message: str, date: datetime | None = None):
+    """Build a mock commit object."""
+    c = MagicMock()
+    c.commit.message = message
+    c.commit.committer.date = date or datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return c
+
+
+def _make_comment(login: str, body: str, created_at: datetime | None = None):
+    """Build a mock issue comment."""
+    c = MagicMock()
+    c.user.login = login
+    c.body = body
+    c.created_at = created_at or datetime(2025, 1, 1, tzinfo=timezone.utc)
+    return c
+
+
+def _make_pr(
+    number: int,
+    ci_status: str,
+    comments: list | None = None,
+    commits: list | None = None,
+    blender_commit: bool = False,
+    is_dependabot: bool = True,
+):
+    """Build a mock PR with configurable CI, comments, and commits.
+
+    ci_status: "passing" | "failing" | "pending"
+    """
+    pr = MagicMock()
+    pr.number = number
+    pr.title = f"Bump foo from 1.0.0 to 2.0.0"
+    pr.user.login = "dependabot[bot]" if is_dependabot else "octocat"
+    type(pr.head).sha = PropertyMock(return_value="abc123")
+
+    # Commits
+    commit_list = list(commits or [])
+    if blender_commit:
+        commit_list.append(
+            _make_commit(
+                "BLEnder fix(foo): update lockfile",
+                datetime(2025, 1, 2, tzinfo=timezone.utc),
+            )
+        )
+    if not commit_list:
+        commit_list.append(_make_commit("Bump foo from 1.0.0 to 2.0.0"))
+    pr.get_commits.return_value = commit_list
+
+    # Comments
+    pr.get_issue_comments.return_value = list(comments or [])
+
+    return pr, ci_status
+
+
+def _build_repo(prs: list[tuple[MagicMock, str]]):
+    """Build a mock repo with .blender config and given PRs."""
+    repo = MagicMock()
+    repo.full_name = "owner/repo"
+    # has_blender_config returns True
+    repo.get_contents.return_value = True
+
+    pr_objects = [pr for pr, _ in prs]
+    repo.get_pulls.return_value = pr_objects
+
+    # Patch check_pr_status to return the configured status
+    status_map = {pr.number: status for pr, status in prs}
+
+    def mock_check_pr_status(_repo, pr):
+        s = status_map[pr.number]
+        if s == "passing":
+            return "automerge"
+        elif s == "failing":
+            return "fix"
+        else:
+            return None
+
+    return repo, mock_check_pr_status
+
+
+# --- CI-failing PRs (result == "fix") ---
+
+
+class TestFixDispatch:
+    def test_fresh_pr_dispatches_fix(self):
+        """#1: No BLEnder activity -> dispatch fix."""
+        pr, status = _make_pr(1, "failing")
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_blender_commit_skips(self):
+        """#2: BLEnder commit exists -> skip."""
+        pr, status = _make_pr(2, "failing", blender_commit=True)
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+    def test_fresh_picked_up_comment_skips(self):
+        """#3: Fresh 'picked up' comment -> skip."""
+        commit_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        comment_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        pr, status = _make_pr(
+            3,
+            "failing",
+            commits=[_make_commit("Bump foo", commit_date)],
+            comments=[
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+    def test_stale_picked_up_comment_dispatches(self):
+        """#4: Stale 'picked up' comment (before force-push) -> dispatch fix."""
+        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        pr, status = _make_pr(
+            4,
+            "failing",
+            commits=[_make_commit("Bump foo", commit_date)],
+            comments=[
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_fresh_could_not_fix_skips(self):
+        """#5: Fresh 'could not fix' comment -> skip."""
+        commit_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        comment_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        pr, status = _make_pr(
+            5,
+            "failing",
+            commits=[_make_commit("Bump foo", commit_date)],
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder could not fix this PR automatically.",
+                    comment_date,
+                )
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+    def test_stale_could_not_fix_dispatches(self):
+        """#6: Stale 'could not fix' comment -> dispatch fix."""
+        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        pr, status = _make_pr(
+            6,
+            "failing",
+            commits=[_make_commit("Bump foo", commit_date)],
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder could not fix this PR automatically.",
+                    comment_date,
+                )
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_automerge_comment_does_not_block_fix(self):
+        """#7: 'will not auto-merge' comment only -> dispatch fix."""
+        pr, status = _make_pr(
+            7,
+            "failing",
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder: will not auto-merge (CI has 1 failure(s)).",
+                    datetime(2025, 1, 2, tzinfo=timezone.utc),
+                )
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_retry_comment_does_not_block_fix(self):
+        """#8: 'skipped (...). Will retry' comment only -> dispatch fix."""
+        pr, status = _make_pr(
+            8,
+            "failing",
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder: skipped (score unknown). Will retry on next scheduled run.",
+                    datetime(2025, 1, 2, tzinfo=timezone.utc),
+                )
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_blender_commit_takes_precedence_over_stale_comment(self):
+        """#9: BLEnder commit + stale comment -> skip (commit wins)."""
+        comment_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        commit_date = datetime(2025, 1, 2, tzinfo=timezone.utc)
+        pr, status = _make_pr(
+            9,
+            "failing",
+            blender_commit=True,
+            commits=[_make_commit("Bump foo", commit_date)],
+            comments=[
+                _make_comment("blender[bot]", "BLEnder picked up this PR.", comment_date)
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+
+# --- CI-passing PRs (result == "automerge") ---
+
+
+class TestAutomergeDispatch:
+    def test_passing_pr_dispatches_automerge(self):
+        """#10: No activity -> dispatch automerge."""
+        pr, status = _make_pr(10, "passing")
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "automerge"
+
+    def test_blender_comments_do_not_block_automerge(self):
+        """#11: BLEnder comments don't block automerge dispatch."""
+        pr, status = _make_pr(
+            11,
+            "passing",
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder picked up this PR.",
+                    datetime(2025, 1, 2, tzinfo=timezone.utc),
+                )
+            ],
+        )
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert len(actions) == 1
+        assert actions[0].action == "automerge"
+
+
+# --- CI-pending PRs ---
+
+
+class TestPendingPR:
+    def test_pending_pr_skipped(self):
+        """#12: Pending checks -> skip."""
+        pr, status = _make_pr(12, "pending")
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+
+# --- Edge cases ---
+
+
+class TestEdgeCases:
+    def test_non_dependabot_pr_skipped(self):
+        """#13: Non-dependabot PR -> not in the list at all."""
+        pr, status = _make_pr(13, "failing", is_dependabot=False)
+        repo, checker = _build_repo([(pr, status)])
+        with patch("scripts.sweep.check_pr_status", side_effect=checker):
+            actions = process_repo(repo)
+        assert actions == []
+
+    def test_no_blender_config_skips(self):
+        """#14: No .blender config -> skip repo."""
+        from github.GithubException import UnknownObjectException
+
+        repo = MagicMock()
+        repo.get_contents.side_effect = UnknownObjectException(404, {}, {})
+        actions = process_repo(repo)
+        assert actions == []
+
+    def test_check_pr_status_exception_continues(self):
+        """#15: Exception in check_pr_status -> skip PR, don't crash."""
+        pr, _ = _make_pr(15, "failing")
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo.get_contents.return_value = True
+        repo.get_pulls.return_value = [pr]
+
+        with patch(
+            "scripts.sweep.check_pr_status", side_effect=RuntimeError("API error")
+        ):
+            actions = process_repo(repo)
+        assert actions == []


### PR DESCRIPTION
Three bugs fixed:

1. Automerge posted "will not auto-merge" on CI failures that the fix workflow handles. New CIFailurePR exception suppresses the comment.

2. Fix workflow left no comment when Claude failed to fix a PR. New "Comment if fix failed" step posts when no commit was pushed.

3. Sweep skipped re-dispatch after dependabot force-pushed because the old "picked up" comment blocked it. Now only fresh fix-related comments (posted after the latest commit) block dispatch.