### PR TITLE
fix: unblock auto-merge for reviewed PRs, lower compat threshold, slim prompt

### DIFF
--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -56,7 +56,7 @@ jobs:
           private-key: ${{ secrets.BLENDER_APP_PRIVATE_KEY }}
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
-          permission-contents: read
+          permission-contents: write
           permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -5,7 +5,7 @@ automerge:
   dry_run: false
   allow_major: false
   review_major: true
-  min_compatibility_score: 80
+  min_compatibility_score: 70
   check_advisories: true
 
 fix:

--- a/prompts/major-bump-prompt.md
+++ b/prompts/major-bump-prompt.md
@@ -32,34 +32,24 @@ Search the codebase for imports, requires, API calls, and configuration referenc
 - Test files that exercise the dependency
 - Build scripts or CI config that reference it
 
-### Step 2: Read the dependency source code
+### Step 2: Review breaking changes from release notes
 
-Read the installed dependency code directly (in `node_modules/`, `site-packages/`, or equivalent) to understand what changed between versions. Compare the public API surface.
-
-### Step 3: Identify test coverage
-
-For each callsite you found, determine:
-- Is there a test that exercises this code path?
-- Would the test catch a breaking change in the dependency's behavior?
-
-### Step 4: Review breaking changes
-
-From the release notes, PR body, and the dependency source code, identify all breaking changes. This includes:
+Use the release notes and PR body above to identify breaking changes. Do NOT read the dependency's own source code in `node_modules/`, `site-packages/`, or equivalent — that wastes turns on large libraries. The release notes are your primary source. Breaking changes include:
 - Removed functions, classes, or methods
 - Changed function signatures
 - Dropped runtime version support (Python, Node, etc.)
 - Changed default behavior
 - Renamed exports
 
-### Step 5: Cross-reference
+### Step 3: Cross-reference usage against breaking changes
 
-For each breaking change, check: does this codebase use the affected API? If yes, would existing tests catch the breakage?
+For each breaking change from the release notes, check: does this codebase use the affected API? For each callsite, is there a test that would catch the breakage?
 
-### Step 6: Check CI status
+### Step 4: Check CI status
 
 Are all CI checks passing on this PR? If not, what failed and is it related to the major bump?
 
-### Step 7: Write your verdict
+### Step 5: Write your verdict
 
 Write your verdict to `.blender-verdict.json` using the Bash tool:
 

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -90,7 +90,7 @@ class Config:
     repo_name: str
     token: str
     dry_run: bool
-    min_compatibility_score: int = 80
+    min_compatibility_score: int = 70
     allow_major: bool = False
 
 
@@ -418,7 +418,7 @@ def _check_badge_svg(
     old_version: str,
     new_version: str,
     label: str,
-    min_score: int = 80,
+    min_score: int = 70,
 ) -> int | None:
     """Parse a badge SVG and return score, None for unknown-ok, or raise."""
     if COMPAT_UNKNOWN_RE.search(badge_svg):
@@ -441,7 +441,7 @@ def _check_badge_svg(
 def _check_group_compatibility(
     deps: list[DependencyUpdate],
     raw_ecosystem: str,
-    min_compat_score: int = 80,
+    min_compat_score: int = 70,
 ) -> int | None:
     """Check compatibility for each dep in a group PR. Return min score."""
     min_score: int | None = None
@@ -482,7 +482,7 @@ def _check_group_compatibility(
 def gate_compatibility(
     pr: PullRequest,
     meta: PRMetadata,
-    min_compat_score: int = 80,
+    min_compat_score: int = 70,
 ) -> int | None:
     """Gate 4: Compatibility score >= min_compat_score."""
     # Try badge URL from PR body (single-dep PRs)
@@ -609,7 +609,7 @@ def load_config() -> Config:
         print("Error: GH_TOKEN is required.")
         sys.exit(1)
 
-    min_compat = int(os.environ.get("MIN_COMPAT_SCORE", "80"))
+    min_compat = int(os.environ.get("MIN_COMPAT_SCORE", "70"))
     allow_major = os.environ.get("ALLOW_MAJOR", "false").lower() in (
         "true",
         "1",


### PR DESCRIPTION
The review workflow token had contents:read, but enablePullRequestAutoMerge needs contents:write. This blocked merging PRs that BLEnder already approved (e.g. fx-private-relay#6519).

Lower the compatibility score threshold from 80% to 70% so PRs like slack-github-action (scored 76%) aren't held up.

Rewrite the major-bump prompt to skip reading dependency source code in site-packages/node_modules. Claude burned all 15 turns exploring cryptography's C-extension tree and never wrote a verdict. The new prompt relies on release notes and cross-references against the project's own usage.