### PR TITLE
fix: put review details in the approval body, not a separate comment

### DIFF
--- a/scripts/post_major_review.py
+++ b/scripts/post_major_review.py
@@ -5,7 +5,7 @@ This script has GH_TOKEN but does NOT have ANTHROPIC_API_KEY.
 It reads .blender-verdict.json written by Claude.
 
 Actions:
-  safe + high/medium confidence -> approve PR, enable auto-merge, post comment
+  safe + high/medium confidence -> approve PR (review body has details), enable auto-merge
   not safe or low confidence    -> post detailed skip comment
   no verdict file               -> post fallback comment
 
@@ -43,15 +43,14 @@ def post_comment(pr: PullRequest, body: str, dry_run: bool) -> None:
     pr.create_issue_comment(body)
 
 
-def approve_and_merge(pr: PullRequest, confidence: str, dry_run: bool) -> str | None:
+def approve_and_merge(pr: PullRequest, review_body: str, dry_run: bool) -> str | None:
     """Approve the PR and enable auto-merge.
 
     Returns None on success, or an error message if auto-merge failed.
     The approval is posted regardless.
     """
-    review_body = Verdict.APPROVED.comment(f"({confidence} confidence).")
     if dry_run:
-        print("DRY_RUN: would approve and enable auto-merge")
+        print(f"DRY_RUN: would approve with body:\n{review_body}")
         return None
     pr.create_review(event="APPROVE", body=review_body)
     return enable_auto_merge(pr)
@@ -106,12 +105,18 @@ def main() -> None:
     print(f"Reason: {reason}")
 
     if safe and confidence != "low":
-        merge_err = approve_and_merge(pr, confidence, dry_run)
-        auto_merge_note = ""
+        review_body = (
+            f"{Verdict.APPROVED.comment(f'({confidence} confidence).')}\n\n"
+            f"**Reason:** {reason}\n\n"
+            f"**Breaking changes:** "
+            f"{breaking_changes or 'None that affect this codebase'}\n"
+            f"**Test coverage:** {test_coverage}"
+        )
+        merge_err = approve_and_merge(pr, review_body, dry_run)
         if merge_err:
             print(f"Warning: auto-merge failed: {merge_err}")
             auto_merge_note = (
-                "\n\n> **Note:** auto-merge could not be enabled"
+                f"\n\n> **Note:** auto-merge could not be enabled"
                 f" ({merge_err}).\n"
                 "> A maintainer can merge this PR manually, or"
                 " [enable auto-merge](https://docs.github.com/en/"
@@ -121,16 +126,7 @@ def main() -> None:
                 "repository) on the repo so BLEnder can merge"
                 " safe updates in the future."
             )
-        comment = (
-            f"{Verdict.SAFE.comment('to merge.')}\n\n"
-            f"**Confidence:** {confidence}\n"
-            f"**Reason:** {reason}\n\n"
-            f"**Breaking changes:** "
-            f"{breaking_changes or 'None that affect this codebase'}\n"
-            f"**Test coverage:** {test_coverage}"
-            f"{auto_merge_note}"
-        )
-        post_comment(pr, comment, dry_run)
+            post_comment(pr, auto_merge_note, dry_run)
         if not dry_run:
             if merge_err:
                 print("Done. PR approved. Auto-merge not available.")

--- a/tests/scripts/test_post_major_review.py
+++ b/tests/scripts/test_post_major_review.py
@@ -81,11 +81,12 @@ def test_safe_verdict_approves_and_merges(
     main()
 
     pr.create_review.assert_called_once()
+    review_body = pr.create_review.call_args[1]["body"]
+    assert review_body.startswith("APPROVED:")
+    assert "No breaking changes" in review_body
     mock_merge.assert_called_once_with(pr)
-    pr.create_issue_comment.assert_called_once()
-    comment_text = pr.create_issue_comment.call_args.args[0]
-    assert comment_text.startswith("SAFE:")
-    assert "auto-merge could not be enabled" not in comment_text
+    # No separate comment when auto-merge succeeds
+    pr.create_issue_comment.assert_not_called()
 
 
 @patch("scripts.post_major_review.Github")
@@ -113,8 +114,10 @@ def test_safe_verdict_posts_comment_when_automerge_fails(
     main()
 
     pr.create_review.assert_called_once()
+    review_body = pr.create_review.call_args[1]["body"]
+    assert review_body.startswith("APPROVED:")
+    assert "No breaking changes" in review_body
+    # Auto-merge failure posts a separate warning comment
     pr.create_issue_comment.assert_called_once()
     comment_text = pr.create_issue_comment.call_args.args[0]
-    assert comment_text.startswith("SAFE:")
     assert "auto-merge could not be enabled" in comment_text
-    assert "enable auto-merge" in comment_text


### PR DESCRIPTION
The dedup guard in post_comment checked has_blender_verdict, which matched the APPROVED review just posted by approve_and_merge. The detailed comment with reason, breaking changes, and test coverage was silently dropped every time.

Move all verdict details into the review body itself. A separate comment is only posted when auto-merge fails.