### PR TITLE
fix: use --output-format json in verbose mode to capture full session

### DIFF
--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -179,6 +179,14 @@ jobs:
           NEW_VERSION: ${{ steps.pr-meta.outputs.new_version }}
           ECOSYSTEM: ${{ steps.pr-meta.outputs.ecosystem }}
 
+      - name: Upload gathered context
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: blender-context
+          path: target/.blender-context/
+          retention-days: 14
+
       - name: Run Claude review
         working-directory: target
         run: ${{ github.workspace }}/scripts/run-claude.sh

--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -178,6 +178,15 @@ jobs:
           OLD_VERSION: ${{ steps.pr-meta.outputs.old_version }}
           NEW_VERSION: ${{ steps.pr-meta.outputs.new_version }}
           ECOSYSTEM: ${{ steps.pr-meta.outputs.ecosystem }}
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+
+      - name: Upload gathered context
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: blender-context
+          path: target/.blender-context/
+          retention-days: 14
 
       - name: Run Claude review
         working-directory: target

--- a/.github/workflows/chore-review-major-dependabot-update.yml
+++ b/.github/workflows/chore-review-major-dependabot-update.yml
@@ -178,15 +178,6 @@ jobs:
           OLD_VERSION: ${{ steps.pr-meta.outputs.old_version }}
           NEW_VERSION: ${{ steps.pr-meta.outputs.new_version }}
           ECOSYSTEM: ${{ steps.pr-meta.outputs.ecosystem }}
-          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-
-      - name: Upload gathered context
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: blender-context
-          path: target/.blender-context/
-          retention-days: 14
 
       - name: Run Claude review
         working-directory: target

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -129,15 +129,6 @@ jobs:
           PROMPT_TEMPLATE: .blender/fix-dependabot-prompt.md
           INSTALL_FAILED: ${{ steps.install.outcome == 'failure' && 'true' || 'false' }}
           INSTALL_LOG_FILE: /tmp/install-output.log
-          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
-
-      - name: Upload gathered context
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: blender-context
-          path: target/.blender-context/
-          retention-days: 14
 
       - name: Comment on PR
         working-directory: target

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -129,6 +129,15 @@ jobs:
           PROMPT_TEMPLATE: .blender/fix-dependabot-prompt.md
           INSTALL_FAILED: ${{ steps.install.outcome == 'failure' && 'true' || 'false' }}
           INSTALL_LOG_FILE: /tmp/install-output.log
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+
+      - name: Upload gathered context
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: blender-context
+          path: target/.blender-context/
+          retention-days: 14
 
       - name: Comment on PR
         working-directory: target

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -120,6 +120,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code@stable
 
       - name: Gather PR context
+        id: gather
         working-directory: target
         run: ${{ github.workspace }}/scripts/gather-context.sh
         env:
@@ -129,6 +130,32 @@ jobs:
           PROMPT_TEMPLATE: .blender/fix-dependabot-prompt.md
           INSTALL_FAILED: ${{ steps.install.outcome == 'failure' && 'true' || 'false' }}
           INSTALL_LOG_FILE: /tmp/install-output.log
+
+      - name: Upload gathered context
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: blender-context
+          path: target/.blender-context/
+          retention-days: 14
+
+      - name: Warn about CircleCI
+        if: steps.gather.outputs.HAS_CIRCLECI_FAILURE == 'true'
+        working-directory: target
+        run: |
+          BODY=$(cat <<'COMMENT'
+          > **Note:** This PR has failing CircleCI checks.
+          > BLEnder cannot access CircleCI log output, so it
+          > may not be able to diagnose or fix the failure.
+          > Consider migrating CI to GitHub Actions so BLEnder
+          > can read failure logs directly.
+          COMMENT
+          )
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ inputs.target_repo }}
 
       - name: Comment on PR
         working-directory: target

--- a/scripts/gather-context.sh
+++ b/scripts/gather-context.sh
@@ -165,10 +165,15 @@ if [ -n "$failing_checks" ]; then
       ci_logs="${ci_logs}Annotations:
 ${annotations}
 "
-    elif [ -n "$target_url" ]; then
-      ci_logs="${ci_logs}CircleCI URL: ${target_url}
-(Log not available via API. Run the check locally to see errors.)
+    elif [ -n "$target_url" ] && [[ "$target_url" == *circleci* ]]; then
+      ci_logs="${ci_logs}CircleCI check: ${check_name}
+URL: ${target_url}
+WARNING: BLEnder cannot fetch CircleCI log output. You must reproduce
+the failure locally using the commands in the fix prompt. If you cannot
+determine the root cause, say so — do not guess.
 "
+      echo "  Warning: CircleCI failure — logs not available."
+      echo "HAS_CIRCLECI_FAILURE=true" >> "${GITHUB_OUTPUT:-/dev/null}"
     else
       ci_logs="${ci_logs}(No log annotations available. Run the check locally to see errors.)
 "
@@ -218,5 +223,17 @@ prompt="${prompt//\{\{INSTALL_ERROR\}\}/$install_error}"
 
 # Write prompt to file for run-claude.sh
 echo "$prompt" > .blender-prompt
-
 echo "Prompt written to .blender-prompt"
+
+# --- Save gathered context for workflow artifacts ---
+CONTEXT_DIR="${CONTEXT_DIR:-.blender-context}"
+mkdir -p "$CONTEXT_DIR"
+echo "$safe_diff"    > "$CONTEXT_DIR/pr-diff.txt"
+echo "$safe_body"    > "$CONTEXT_DIR/pr-body.md"
+echo "$safe_notes"   > "$CONTEXT_DIR/release-notes.md"
+echo "$safe_ci"      > "$CONTEXT_DIR/ci-status.txt"
+echo "$safe_checks"  > "$CONTEXT_DIR/failing-checks.txt"
+echo "$safe_logs"    > "$CONTEXT_DIR/ci-logs.txt"
+cp "$PROMPT_TEMPLATE" "$CONTEXT_DIR/prompt-template.md"
+cp .blender-prompt     "$CONTEXT_DIR/prompt-final.md"
+echo "Context saved to $CONTEXT_DIR/"

--- a/scripts/gather-context.sh
+++ b/scripts/gather-context.sh
@@ -58,6 +58,56 @@ sanitize_for_prompt() {
   echo "$input"
 }
 
+# --- Fetch CircleCI job logs via v1.1 API ---
+fetch_circleci_log() {
+  local url="$1"
+  # Parse job number and project from CircleCI URL:
+  # https://app.circleci.com/pipelines/github/ORG/REPO/PIPELINE/workflows/WF_ID/jobs/JOB_NUM
+  local job_number org project
+  if [[ "$url" =~ app\.circleci\.com/pipelines/github/([^/]+)/([^/]+)/[0-9]+/workflows/[^/]+/jobs/([0-9]+) ]]; then
+    org="${BASH_REMATCH[1]}"
+    project="${BASH_REMATCH[2]}"
+    job_number="${BASH_REMATCH[3]}"
+  else
+    return 1
+  fi
+
+  local slug="gh/${org}/${project}"
+
+  # Fetch build details (includes steps with output URLs)
+  local build_json
+  build_json=$(curl -sf -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+    "https://circleci.com/api/v1.1/project/${slug}/${job_number}" 2>/dev/null) || return 1
+
+  # Find failed steps and fetch their output
+  local output_urls
+  output_urls=$(echo "$build_json" | jq -r '
+    .steps[]
+    | .actions[]
+    | select(.status == "failed" and .has_output == true)
+    | .output_url' 2>/dev/null) || return 1
+
+  if [ -z "$output_urls" ]; then
+    return 1
+  fi
+
+  local log_text=""
+  while IFS= read -r output_url; do
+    [ -z "$output_url" ] && continue
+    local step_log
+    step_log=$(curl -sf "$output_url" 2>/dev/null \
+      | jq -r '.[].message // empty' 2>/dev/null) || continue
+    log_text="${log_text}${step_log}"
+  done <<< "$output_urls"
+
+  if [ -z "$log_text" ]; then
+    return 1
+  fi
+
+  # Return last 200 lines to keep prompt size reasonable
+  echo "$log_text" | tail -200
+}
+
 echo "BLEnder gather-context: PR #${PR_NUMBER} repo=${REPO}"
 
 # --- Fetch PR metadata ---
@@ -166,9 +216,20 @@ if [ -n "$failing_checks" ]; then
 ${annotations}
 "
     elif [ -n "$target_url" ]; then
-      ci_logs="${ci_logs}CircleCI URL: ${target_url}
+      # Try to fetch CircleCI logs via their API
+      circleci_log=""
+      if [ -n "${CIRCLECI_TOKEN:-}" ]; then
+        circleci_log=$(fetch_circleci_log "$target_url" || true)
+      fi
+      if [ -n "$circleci_log" ]; then
+        ci_logs="${ci_logs}CircleCI log (last 200 lines):
+${circleci_log}
+"
+      else
+        ci_logs="${ci_logs}CircleCI URL: ${target_url}
 (Log not available via API. Run the check locally to see errors.)
 "
+      fi
     else
       ci_logs="${ci_logs}(No log annotations available. Run the check locally to see errors.)
 "
@@ -220,3 +281,16 @@ prompt="${prompt//\{\{INSTALL_ERROR\}\}/$install_error}"
 echo "$prompt" > .blender-prompt
 
 echo "Prompt written to .blender-prompt"
+
+# --- Save gathered context for workflow artifacts ---
+CONTEXT_DIR="${CONTEXT_DIR:-.blender-context}"
+mkdir -p "$CONTEXT_DIR"
+echo "$safe_diff"    > "$CONTEXT_DIR/pr-diff.txt"
+echo "$safe_body"    > "$CONTEXT_DIR/pr-body.md"
+echo "$safe_notes"   > "$CONTEXT_DIR/release-notes.md"
+echo "$safe_ci"      > "$CONTEXT_DIR/ci-status.txt"
+echo "$safe_checks"  > "$CONTEXT_DIR/failing-checks.txt"
+echo "$safe_logs"    > "$CONTEXT_DIR/ci-logs.txt"
+cp "$PROMPT_TEMPLATE" "$CONTEXT_DIR/prompt-template.md"
+cp .blender-prompt     "$CONTEXT_DIR/prompt-final.md"
+echo "Context saved to $CONTEXT_DIR/"

--- a/scripts/gather-context.sh
+++ b/scripts/gather-context.sh
@@ -58,56 +58,6 @@ sanitize_for_prompt() {
   echo "$input"
 }
 
-# --- Fetch CircleCI job logs via v1.1 API ---
-fetch_circleci_log() {
-  local url="$1"
-  # Parse job number and project from CircleCI URL:
-  # https://app.circleci.com/pipelines/github/ORG/REPO/PIPELINE/workflows/WF_ID/jobs/JOB_NUM
-  local job_number org project
-  if [[ "$url" =~ app\.circleci\.com/pipelines/github/([^/]+)/([^/]+)/[0-9]+/workflows/[^/]+/jobs/([0-9]+) ]]; then
-    org="${BASH_REMATCH[1]}"
-    project="${BASH_REMATCH[2]}"
-    job_number="${BASH_REMATCH[3]}"
-  else
-    return 1
-  fi
-
-  local slug="gh/${org}/${project}"
-
-  # Fetch build details (includes steps with output URLs)
-  local build_json
-  build_json=$(curl -sf -H "Circle-Token: ${CIRCLECI_TOKEN}" \
-    "https://circleci.com/api/v1.1/project/${slug}/${job_number}" 2>/dev/null) || return 1
-
-  # Find failed steps and fetch their output
-  local output_urls
-  output_urls=$(echo "$build_json" | jq -r '
-    .steps[]
-    | .actions[]
-    | select(.status == "failed" and .has_output == true)
-    | .output_url' 2>/dev/null) || return 1
-
-  if [ -z "$output_urls" ]; then
-    return 1
-  fi
-
-  local log_text=""
-  while IFS= read -r output_url; do
-    [ -z "$output_url" ] && continue
-    local step_log
-    step_log=$(curl -sf "$output_url" 2>/dev/null \
-      | jq -r '.[].message // empty' 2>/dev/null) || continue
-    log_text="${log_text}${step_log}"
-  done <<< "$output_urls"
-
-  if [ -z "$log_text" ]; then
-    return 1
-  fi
-
-  # Return last 200 lines to keep prompt size reasonable
-  echo "$log_text" | tail -200
-}
-
 echo "BLEnder gather-context: PR #${PR_NUMBER} repo=${REPO}"
 
 # --- Fetch PR metadata ---
@@ -216,20 +166,9 @@ if [ -n "$failing_checks" ]; then
 ${annotations}
 "
     elif [ -n "$target_url" ]; then
-      # Try to fetch CircleCI logs via their API
-      circleci_log=""
-      if [ -n "${CIRCLECI_TOKEN:-}" ]; then
-        circleci_log=$(fetch_circleci_log "$target_url" || true)
-      fi
-      if [ -n "$circleci_log" ]; then
-        ci_logs="${ci_logs}CircleCI log (last 200 lines):
-${circleci_log}
-"
-      else
-        ci_logs="${ci_logs}CircleCI URL: ${target_url}
+      ci_logs="${ci_logs}CircleCI URL: ${target_url}
 (Log not available via API. Run the check locally to see errors.)
 "
-      fi
     else
       ci_logs="${ci_logs}(No log annotations available. Run the check locally to see errors.)
 "
@@ -281,16 +220,3 @@ prompt="${prompt//\{\{INSTALL_ERROR\}\}/$install_error}"
 echo "$prompt" > .blender-prompt
 
 echo "Prompt written to .blender-prompt"
-
-# --- Save gathered context for workflow artifacts ---
-CONTEXT_DIR="${CONTEXT_DIR:-.blender-context}"
-mkdir -p "$CONTEXT_DIR"
-echo "$safe_diff"    > "$CONTEXT_DIR/pr-diff.txt"
-echo "$safe_body"    > "$CONTEXT_DIR/pr-body.md"
-echo "$safe_notes"   > "$CONTEXT_DIR/release-notes.md"
-echo "$safe_ci"      > "$CONTEXT_DIR/ci-status.txt"
-echo "$safe_checks"  > "$CONTEXT_DIR/failing-checks.txt"
-echo "$safe_logs"    > "$CONTEXT_DIR/ci-logs.txt"
-cp "$PROMPT_TEMPLATE" "$CONTEXT_DIR/prompt-template.md"
-cp .blender-prompt     "$CONTEXT_DIR/prompt-final.md"
-echo "Context saved to $CONTEXT_DIR/"

--- a/scripts/run-claude.sh
+++ b/scripts/run-claude.sh
@@ -60,9 +60,20 @@ else
 fi
 
 echo "Running Claude Code (mode=${BLENDER_MODE}, tools=${ALLOWED_TOOLS}, turns=${MAX_TURNS}, budget=\$${MAX_BUDGET})..."
+
+# In verbose mode, use --output-format json to capture the full session
+# (tool calls, tool results, reasoning).  Normal mode uses -p for just
+# the final text response.
+if [ "${CLAUDE_VERBOSE:-false}" = "true" ]; then
+  OUTPUT_FLAGS="-p --output-format json"
+else
+  OUTPUT_FLAGS="-p"
+fi
+
 claude_exit=0
+# shellcheck disable=SC2086  # intentional word-splitting of OUTPUT_FLAGS
 claude \
-  -p \
+  $OUTPUT_FLAGS \
   --verbose \
   --max-turns "$MAX_TURNS" \
   --max-budget-usd "$MAX_BUDGET" \
@@ -78,7 +89,12 @@ claude \
 line_count=$(wc -l < "$CLAUDE_LOG")
 echo "Claude finished (exit=${claude_exit}, ${line_count} lines of output)."
 if [ "${CLAUDE_VERBOSE:-false}" = "true" ]; then
-  cat "$CLAUDE_LOG"
+  # Pretty-print the JSON session log for readability in CI
+  if command -v jq &>/dev/null; then
+    jq . "$CLAUDE_LOG" 2>/dev/null || cat "$CLAUDE_LOG"
+  else
+    cat "$CLAUDE_LOG"
+  fi
 else
   echo "Set CLAUDE_VERBOSE=true to see full output."
 fi


### PR DESCRIPTION
The -p flag only outputs Claude's final text response. Tool calls, tool results, and reasoning are invisible. When Claude hits max turns there is no final response, so the log is empty — 0 lines.

In verbose mode, switch to --output-format json which dumps the full conversation. Pretty-print with jq for readability in CI logs.