### PR TITLE
feat: add npm_bump action for transitive dependency PRs

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -65,7 +65,27 @@ jobs:
           install-sandbox: 'true'
           install-claude: 'true'
 
+      - name: Check for existing BLEnder PR
+        id: existing-pr
+        run: |
+          PR=$(gh pr list --repo "$REPO" \
+            --search "$PACKAGE in:title" \
+            --json number,title,headRefName \
+            --jq '.[] | select(.headRefName | startswith("blender/")) | .number' \
+            | head -1)
+          if [ -n "$PR" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice ::Skipping investigation — existing BLEnder PR #${PR} for ${PACKAGE}"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.setup.outputs.token }}
+          REPO: ${{ inputs.target_repo }}
+          PACKAGE: ${{ inputs.alert_package }}
+
       - name: Gather alert context
+        if: steps.existing-pr.outputs.skip != 'true'
         working-directory: target
         run: ${{ github.workspace }}/scripts/gather-alert-context.sh
         env:
@@ -77,6 +97,7 @@ jobs:
           ALERT_ECOSYSTEM: ${{ inputs.alert_ecosystem }}
 
       - name: Run Claude investigation
+        if: steps.existing-pr.outputs.skip != 'true'
         working-directory: target
         run: ${{ github.workspace }}/scripts/run-claude.sh
         env:
@@ -88,6 +109,7 @@ jobs:
           CLAUDE_VERBOSE: ${{ inputs.verbose }}
 
       - name: Upload verdict
+        if: steps.existing-pr.outputs.skip != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: alert-verdict
@@ -139,6 +161,25 @@ jobs:
           ALERT_PATCHED_VERSION: ${{ inputs.alert_patched_version }}
           DRY_RUN: ${{ inputs.dry_run }}
           DISMISS_UNAFFECTED: ${{ steps.setup.outputs.dismiss_unaffected }}
+
+      # --- npm transitive dependency bump (lock file only) ---
+      - name: Run npm update
+        if: steps.post-action.outputs.action == 'npm_bump'
+        working-directory: target
+        run: npm update "$NPM_PACKAGE"
+        env:
+          NPM_PACKAGE: ${{ steps.post-action.outputs.npm_package }}
+
+      - name: Create npm bump PR
+        if: steps.post-action.outputs.action == 'npm_bump' && inputs.dry_run != 'true'
+        working-directory: target
+        run: bash ${{ github.workspace }}/scripts/npm-bump.sh
+        env:
+          PACKAGE: ${{ steps.post-action.outputs.npm_package }}
+          PATCHED_VERSION: ${{ inputs.alert_patched_version }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+          REPO: ${{ inputs.target_repo }}
+          GH_TOKEN: ${{ steps.setup.outputs.token }}
 
       # --- Private fork remediation (only for affected alerts) ---
       - name: Clone private fork

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -34,6 +34,7 @@ def render_markdown(
         "private_fork": "Advisory created with private fork",
         "existing_pr": "Existing Dependabot PR found",
         "bump_pr_created": "Bump PR created",
+        "npm_bump": "npm bump PR created",
     }
     action_text = action_labels.get(action, action)
 
@@ -78,6 +79,7 @@ def annotation_line(
         "dismissed": "alert dismissed",
         "noop": "no action taken",
         "private_fork": "advisory created with private fork",
+        "npm_bump": "npm bump PR created",
     }
     action_text = action_labels.get(action, action)
 

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -34,7 +34,14 @@ fi
 
 PARENT=$(git rev-parse HEAD)
 
-COMMIT=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT")
+# Collect changed files explicitly so we control what gets committed
+CHANGED_FILES=()
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  CHANGED_FILES+=("$file")
+done < <(git diff --name-only)
+
+COMMIT=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
 # Update branch ref
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -2,14 +2,16 @@
 # BLEnder commit: create a verified commit via the GitHub API.
 #
 # Runs after Claude's process exits. Reads commit message from .blender-commit-msg.
-# Uses blob -> tree -> commit -> ref-update to produce a verified commit
-# signed by github-actions[bot].
+# Delegates blob -> tree -> commit to git-commit-api.sh, then updates the
+# branch ref.
 #
 # Environment variables:
 #   GH_TOKEN  -- GitHub token with contents:write (required)
 #   REPO      -- GitHub repo, e.g. mozilla/fx-private-relay (required)
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
   echo "Error: GH_TOKEN and REPO are required."
@@ -31,41 +33,8 @@ if git diff --quiet && git diff --cached --quiet; then
 fi
 
 PARENT=$(git rev-parse HEAD)
-BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
 
-# Upload each changed file as a blob
-TREE_ITEMS="[]"
-while IFS= read -r file; do
-  [ -z "$file" ] && continue
-  BLOB_SHA=$(base64 -w 0 "$file" | \
-    jq -Rs '{"encoding": "base64", "content": .}' | \
-    gh api "repos/${REPO}/git/blobs" \
-    --method POST \
-    --input - \
-    --jq '.sha')
-  TREE_ITEMS=$(echo "$TREE_ITEMS" | jq \
-    --arg path "$file" \
-    --arg sha "$BLOB_SHA" \
-    '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
-done < <(git diff --name-only)
-
-# Create tree from blobs
-TREE_SHA=$(jq -n \
-  --arg base "$BASE_TREE" \
-  --argjson tree "$TREE_ITEMS" \
-  '{"base_tree": $base, "tree": $tree}' | \
-  gh api "repos/${REPO}/git/trees" \
-    --method POST \
-    --input - \
-    --jq '.sha')
-
-# Create verified commit
-COMMIT=$(gh api "repos/${REPO}/git/commits" \
-  --method POST \
-  --field "message=${COMMIT_MSG}" \
-  --field "tree=${TREE_SHA}" \
-  --field "parents[]=${PARENT}" \
-  --jq '.sha')
+COMMIT=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT")
 
 # Update branch ref
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/scripts/git-commit-api.sh
+++ b/scripts/git-commit-api.sh
@@ -5,9 +5,9 @@
 # signed by github-actions[bot]. Prints the new commit SHA to stdout.
 #
 # Usage:
-#   scripts/git-commit-api.sh <commit_msg> <parent_sha> [file1 file2 ...]
+#   scripts/git-commit-api.sh <commit_msg> <parent_sha> <file1> [file2 ...]
 #
-# If no files are passed, reads changed files from `git diff --name-only`.
+# At least one file is required.
 #
 # Environment variables:
 #   GH_TOKEN  -- GitHub token with contents:write (required)
@@ -24,17 +24,9 @@ COMMIT_MSG="${1:?commit message required}"
 PARENT="${2:?parent SHA required}"
 shift 2
 
-# Collect files: positional args or git diff
 FILES=("$@")
 if [ ${#FILES[@]} -eq 0 ]; then
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    FILES+=("$f")
-  done < <(git diff --name-only)
-fi
-
-if [ ${#FILES[@]} -eq 0 ]; then
-  echo "No changed files." >&2
+  echo "Error: at least one file argument is required." >&2
   exit 1
 fi
 

--- a/scripts/git-commit-api.sh
+++ b/scripts/git-commit-api.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# BLEnder shared helper: create a verified commit via the GitHub API.
+#
+# Uploads changed files as blobs, builds a tree, and creates a commit
+# signed by github-actions[bot]. Prints the new commit SHA to stdout.
+#
+# Usage:
+#   scripts/git-commit-api.sh <commit_msg> <parent_sha> [file1 file2 ...]
+#
+# If no files are passed, reads changed files from `git diff --name-only`.
+#
+# Environment variables:
+#   GH_TOKEN  -- GitHub token with contents:write (required)
+#   REPO      -- GitHub repo, e.g. mozilla/fx-private-relay (required)
+
+set -euo pipefail
+
+if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "Error: GH_TOKEN and REPO are required." >&2
+  exit 1
+fi
+
+COMMIT_MSG="${1:?commit message required}"
+PARENT="${2:?parent SHA required}"
+shift 2
+
+# Collect files: positional args or git diff
+FILES=("$@")
+if [ ${#FILES[@]} -eq 0 ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    FILES+=("$f")
+  done < <(git diff --name-only)
+fi
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No changed files." >&2
+  exit 1
+fi
+
+BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
+
+# Upload each file as a blob
+TREE_ITEMS="[]"
+for file in "${FILES[@]}"; do
+  BLOB_SHA=$(base64 -w 0 "$file" | \
+    jq -Rs '{"encoding": "base64", "content": .}' | \
+    gh api "repos/${REPO}/git/blobs" \
+    --method POST \
+    --input - \
+    --jq '.sha')
+  TREE_ITEMS=$(echo "$TREE_ITEMS" | jq \
+    --arg path "$file" \
+    --arg sha "$BLOB_SHA" \
+    '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+done
+
+# Create tree
+TREE_SHA=$(jq -n \
+  --arg base "$BASE_TREE" \
+  --argjson tree "$TREE_ITEMS" \
+  '{"base_tree": $base, "tree": $tree}' | \
+  gh api "repos/${REPO}/git/trees" \
+    --method POST \
+    --input - \
+    --jq '.sha')
+
+# Create verified commit
+COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
+  --method POST \
+  --field "message=${COMMIT_MSG}" \
+  --field "tree=${TREE_SHA}" \
+  --field "parents[]=${PARENT}" \
+  --jq '.sha')
+
+echo "$COMMIT_SHA"

--- a/scripts/npm-bump.sh
+++ b/scripts/npm-bump.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# BLEnder npm bump: commit package-lock.json changes via verified commit
+# and open a PR.
+#
+# Runs after `npm update <package>` in the target repo checkout.
+# Uses blob -> tree -> commit -> ref pattern from commit.sh.
+#
+# Environment variables:
+#   GH_TOKEN          -- GitHub token (required, also used as GH_TOKEN for gh cli)
+#   PACKAGE           -- npm package name (required)
+#   PATCHED_VERSION   -- version to bump to (required)
+#   ALERT_NUMBER      -- Dependabot alert number (required)
+#   REPO              -- target repo, e.g. mozilla/blurts-server (required)
+
+set -euo pipefail
+
+if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "Error: GH_TOKEN and REPO are required."
+  exit 1
+fi
+
+if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
+  echo "Error: PACKAGE and ALERT_NUMBER are required."
+  exit 1
+fi
+
+# Check that package-lock.json changed
+if git diff --quiet package-lock.json 2>/dev/null; then
+  echo "package-lock.json unchanged after npm update. Nothing to do."
+  exit 0
+fi
+
+BRANCH_NAME="blender/security-bump-${PACKAGE}"
+COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+
+Resolves Dependabot alert #${ALERT_NUMBER}.
+Created by BLEnder (https://github.com/mozilla/blender)"
+
+DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
+PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
+
+# Upload changed files as blobs (package-lock.json, possibly package.json)
+TREE_ITEMS="[]"
+for file in package-lock.json package.json; do
+  if ! git diff --quiet "$file" 2>/dev/null; then
+    echo "Uploading ${file} ..."
+    BLOB_SHA=$(base64 -w 0 "$file" | \
+      jq -Rs '{"encoding": "base64", "content": .}' | \
+      gh api "repos/${REPO}/git/blobs" \
+      --method POST \
+      --input - \
+      --jq '.sha')
+    TREE_ITEMS=$(echo "$TREE_ITEMS" | jq \
+      --arg path "$file" \
+      --arg sha "$BLOB_SHA" \
+      '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+  fi
+done
+
+# Create tree
+TREE_SHA=$(jq -n \
+  --arg base "$BASE_TREE" \
+  --argjson tree "$TREE_ITEMS" \
+  '{"base_tree": $base, "tree": $tree}' | \
+  gh api "repos/${REPO}/git/trees" \
+    --method POST \
+    --input - \
+    --jq '.sha')
+
+# Create verified commit
+COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
+  --method POST \
+  --field "message=${COMMIT_MSG}" \
+  --field "tree=${TREE_SHA}" \
+  --field "parents[]=${PARENT}" \
+  --jq '.sha')
+
+# Create branch ref
+gh api "repos/${REPO}/git/refs" \
+  --method POST \
+  --field "ref=refs/heads/${BRANCH_NAME}" \
+  --field "sha=${COMMIT_SHA}" || {
+    echo "Branch ${BRANCH_NAME} already exists. Updating."
+    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
+      --method PATCH \
+      --field "sha=${COMMIT_SHA}"
+  }
+
+echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
+
+# Build PR body
+SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+if [ -n "$RUN_ID" ]; then
+  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
+else
+  RUN_LINK="BLEnder investigation"
+fi
+
+PR_BODY="## Summary
+
+Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER}).
+
+This is a transitive dependency update. Only \`package-lock.json\` (and possibly \`package.json\`) changed.
+
+---
+*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
+
+PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
+
+# Check for existing open PR on this branch
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
+  exit 0
+fi
+
+gh pr create \
+  --repo "$REPO" \
+  --head "$BRANCH_NAME" \
+  --base "$DEFAULT_BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY"
+
+echo "PR created."

--- a/scripts/npm-bump.sh
+++ b/scripts/npm-bump.sh
@@ -3,7 +3,7 @@
 # and open a PR.
 #
 # Runs after `npm update <package>` in the target repo checkout.
-# Uses blob -> tree -> commit -> ref pattern from commit.sh.
+# Delegates blob -> tree -> commit to git-commit-api.sh.
 #
 # Environment variables:
 #   GH_TOKEN          -- GitHub token (required, also used as GH_TOKEN for gh cli)
@@ -13,6 +13,8 @@
 #   REPO              -- target repo, e.g. mozilla/blurts-server (required)
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
   echo "Error: GH_TOKEN and REPO are required."
@@ -31,6 +33,14 @@ if git diff --quiet package-lock.json 2>/dev/null; then
 fi
 
 BRANCH_NAME="blender/security-bump-${PACKAGE}"
+
+# Check for existing open PR on this branch — exit before any API calls
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
+  exit 0
+fi
+
 COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
 
 Resolves Dependabot alert #${ALERT_NUMBER}.
@@ -38,43 +48,16 @@ Created by BLEnder (https://github.com/mozilla/blender)"
 
 DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
 PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
-BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
 
-# Upload changed files as blobs (package-lock.json, possibly package.json)
-TREE_ITEMS="[]"
+# Collect changed files
+CHANGED_FILES=()
 for file in package-lock.json package.json; do
   if ! git diff --quiet "$file" 2>/dev/null; then
-    echo "Uploading ${file} ..."
-    BLOB_SHA=$(base64 -w 0 "$file" | \
-      jq -Rs '{"encoding": "base64", "content": .}' | \
-      gh api "repos/${REPO}/git/blobs" \
-      --method POST \
-      --input - \
-      --jq '.sha')
-    TREE_ITEMS=$(echo "$TREE_ITEMS" | jq \
-      --arg path "$file" \
-      --arg sha "$BLOB_SHA" \
-      '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+    CHANGED_FILES+=("$file")
   fi
 done
 
-# Create tree
-TREE_SHA=$(jq -n \
-  --arg base "$BASE_TREE" \
-  --argjson tree "$TREE_ITEMS" \
-  '{"base_tree": $base, "tree": $tree}' | \
-  gh api "repos/${REPO}/git/trees" \
-    --method POST \
-    --input - \
-    --jq '.sha')
-
-# Create verified commit
-COMMIT_SHA=$(gh api "repos/${REPO}/git/commits" \
-  --method POST \
-  --field "message=${COMMIT_MSG}" \
-  --field "tree=${TREE_SHA}" \
-  --field "parents[]=${PARENT}" \
-  --jq '.sha')
+COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
 # Create branch ref
 gh api "repos/${REPO}/git/refs" \
@@ -109,13 +92,6 @@ This is a transitive dependency update. Only \`package-lock.json\` (and possibly
 *Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
 
 PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
-
-# Check for existing open PR on this branch
-EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
-if [ -n "$EXISTING_PR" ]; then
-  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
-  exit 0
-fi
 
 gh pr create \
   --repo "$REPO" \

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -252,23 +252,16 @@ def create_bump_pr(
     patched_version: str,
     alert_number: int,
     dry_run: bool,
-) -> int | str | None:
+) -> int | None:
     """Create a PR that bumps a dependency to the patched version.
 
-    Returns the PR number on success, ``"npm_bump"`` for npm transitive
-    deps (handled by the workflow), or None on failure.
+    Returns the PR number on success, or None on failure.
     """
     import re
 
     if not patched_version:
         print("  No patched version available. Cannot create bump PR.")
         return None
-
-    # npm transitive deps live in package-lock.json. Signal the
-    # workflow to run `npm update` and commit the lock file.
-    if ecosystem == "npm":
-        print("  npm ecosystem — deferring to npm_bump workflow step.")
-        return "npm_bump"
 
     pin_info = find_dependency_pin(repo, package_name, ecosystem)
     if pin_info is None:
@@ -425,26 +418,31 @@ def main() -> None:
             comment_on_pr(repo, existing_pr, reason, dry_run)
             action = "existing_pr"
         elif recommended == "bump_pr":
-            print("  No existing PR. Creating bump PR.")
-            pr_num = create_bump_pr(
-                repo,
-                package_name,
-                ecosystem,
-                patched_version,
-                alert_number,
-                dry_run,
-            )
-            if pr_num == "npm_bump":
+            if ecosystem == "npm" and patched_version:
+                print("  npm ecosystem — deferring to npm_bump workflow step.")
                 action = "npm_bump"
                 write_output("npm_package", package_name)
                 write_output("npm_version", patched_version)
                 write_output("alert_number", str(alert_number))
-            elif pr_num is not None:
-                action = "bump_pr_created"
-                if pr_num > 0:
-                    write_output("bump_pr_number", str(pr_num))
-            else:
+            elif ecosystem == "npm":
+                print("  npm ecosystem but no patched version. Cannot bump.")
                 action = "noop"
+            else:
+                print("  No existing PR. Creating bump PR.")
+                pr_num = create_bump_pr(
+                    repo,
+                    package_name,
+                    ecosystem,
+                    patched_version,
+                    alert_number,
+                    dry_run,
+                )
+                if pr_num is not None:
+                    action = "bump_pr_created"
+                    if pr_num > 0:
+                        write_output("bump_pr_number", str(pr_num))
+                else:
+                    action = "noop"
         elif dismiss_enabled and severity.lower() not in DISMISS_BLOCKED_SEVERITIES:
             print("  Unaffected + dismiss enabled. Dismissing alert.")
             dismiss_alert(repo, alert_number, reason, dry_run)

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -252,16 +252,23 @@ def create_bump_pr(
     patched_version: str,
     alert_number: int,
     dry_run: bool,
-) -> int | None:
+) -> int | str | None:
     """Create a PR that bumps a dependency to the patched version.
 
-    Returns the PR number on success, None on failure.
+    Returns the PR number on success, ``"npm_bump"`` for npm transitive
+    deps (handled by the workflow), or None on failure.
     """
     import re
 
     if not patched_version:
         print("  No patched version available. Cannot create bump PR.")
         return None
+
+    # npm transitive deps live in package-lock.json. Signal the
+    # workflow to run `npm update` and commit the lock file.
+    if ecosystem == "npm":
+        print("  npm ecosystem — deferring to npm_bump workflow step.")
+        return "npm_bump"
 
     pin_info = find_dependency_pin(repo, package_name, ecosystem)
     if pin_info is None:
@@ -281,11 +288,6 @@ def create_bump_pr(
         if new_text == old_text:
             print(f"  Could not update version pin in {file_path}.")
             return None
-    elif ecosystem == "npm":
-        # For npm, updating package.json alone isn't enough (lock file
-        # needs regenerating). Log and skip for now.
-        print("  npm bump PRs require lock file regeneration. Not yet supported.")
-        return None
     else:
         print(f"  Unsupported ecosystem: {ecosystem}")
         return None
@@ -432,7 +434,12 @@ def main() -> None:
                 alert_number,
                 dry_run,
             )
-            if pr_num is not None:
+            if pr_num == "npm_bump":
+                action = "npm_bump"
+                write_output("npm_package", package_name)
+                write_output("npm_version", patched_version)
+                write_output("alert_number", str(alert_number))
+            elif pr_num is not None:
                 action = "bump_pr_created"
                 if pr_num > 0:
                     write_output("bump_pr_number", str(pr_num))

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -123,16 +123,27 @@ def process_repo(repo: Repository) -> list[Action]:
         return actions
 
     print("    Config found. Checking Dependabot PRs...")
-    open_prs = repo.get_pulls(state="open")
+    open_prs = list(repo.get_pulls(state="open"))
     dependabot_prs = [pr for pr in open_prs if pr.user.login == "dependabot[bot]"]
 
-    if not dependabot_prs:
-        print("    No open Dependabot PRs")
-        return actions
+    # BLEnder bump PRs: must be from the BLEnder bot AND on the right branch.
+    # Both conditions prevent an attacker from sneaking a PR into automerge.
+    BLENDER_BOT_LOGIN = "mozilla-blender[bot]"
+    blender_bump_prs = [
+        pr
+        for pr in open_prs
+        if pr.user.login == BLENDER_BOT_LOGIN
+        and pr.head.ref.startswith("blender/security-bump-")
+    ]
 
-    print(f"    Found {len(dependabot_prs)} Dependabot PR(s)")
+    actionable_prs = dependabot_prs + blender_bump_prs
 
-    for pr in dependabot_prs:
+    if dependabot_prs:
+        print(f"    Found {len(dependabot_prs)} Dependabot PR(s)")
+    if blender_bump_prs:
+        print(f"    Found {len(blender_bump_prs)} BLEnder bump PR(s)")
+
+    for pr in actionable_prs:
         try:
             result = check_pr_status(repo, pr)
         except Exception as e:

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -180,7 +180,8 @@ class TestMainFlow:
         defaults.update(env_overrides)
         for k, v in defaults.items():
             monkeypatch.setenv(k, v)
-        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        if "GITHUB_OUTPUT" not in env_overrides:
+            monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
 
         with patch("scripts.post_alert_action.Github") as mock_gh:
             mock_gh.return_value.get_repo.return_value = mock_repo
@@ -327,3 +328,26 @@ class TestMainFlow:
         )
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_npm_bump_outputs_action(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """npm ecosystem with bump_pr verdict emits action=npm_bump."""
+        verdict_file(SAMPLE_VERDICT)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []  # no existing PR
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            ALERT_ECOSYSTEM="npm", ALERT_PATCHED_VERSION="1.0.1",
+            GITHUB_OUTPUT=output_file,
+        )
+
+        outputs = open(output_file).read()
+        assert "action=npm_bump" in outputs
+        assert "npm_package=lodash" in outputs
+        assert "npm_version=1.0.1" in outputs

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -332,7 +332,11 @@ class TestMainFlow:
     def test_npm_bump_outputs_action(
         self, verdict_file, tmp_path, monkeypatch
     ):
-        """npm ecosystem with bump_pr verdict emits action=npm_bump."""
+        """npm ecosystem with bump_pr verdict emits action=npm_bump.
+
+        The npm path never calls create_bump_pr — main() handles it
+        directly by writing outputs for the workflow's npm_bump step.
+        """
         verdict_file(SAMPLE_VERDICT)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
@@ -351,3 +355,28 @@ class TestMainFlow:
         assert "action=npm_bump" in outputs
         assert "npm_package=lodash" in outputs
         assert "npm_version=1.0.1" in outputs
+
+        # npm path should not touch repo contents or create PRs
+        mock_repo.get_contents.assert_not_called()
+        mock_repo.create_pull.assert_not_called()
+
+    def test_npm_bump_no_patched_version(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """npm ecosystem without patched version results in noop."""
+        verdict_file(SAMPLE_VERDICT)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            ALERT_ECOSYSTEM="npm", ALERT_PATCHED_VERSION="",
+            GITHUB_OUTPUT=output_file,
+        )
+
+        outputs = open(output_file).read()
+        assert "action=noop" in outputs

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -49,6 +49,7 @@ def _make_pr(
     pr.number = number
     pr.title = "Bump foo from 1.0.0 to 2.0.0"
     pr.user.login = "dependabot[bot]" if is_dependabot else "octocat"
+    pr.head.ref = "dependabot/npm_and_yarn/foo-2.0.0"
     type(pr.head).sha = PropertyMock(return_value="abc123")
 
     commit_list = list(commits or [])
@@ -228,6 +229,55 @@ class TestAutomergeDispatch:
         actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
         assert actions[0].action == "automerge"
+
+
+# --- BLEnder bump PRs ---
+
+
+def _make_blender_bump_pr(number: int, ci_status: str, package: str = "foo"):
+    """Build a mock BLEnder bump PR."""
+    pr = MagicMock()
+    pr.number = number
+    pr.title = f"chore(deps): bump {package} to 2.0.0"
+    pr.user.login = "mozilla-blender[bot]"
+    pr.head.ref = f"blender/security-bump-{package}"
+    type(pr.head).sha = PropertyMock(return_value="abc123")
+    pr.get_commits.return_value = [_make_commit(f"chore(deps): bump {package}")]
+    pr.get_issue_comments.return_value = []
+    return pr, ci_status
+
+
+class TestBlenderBumpPR:
+    def test_passing_blender_bump_dispatches_automerge(self):
+        """Passing BLEnder bump PR -> automerge."""
+        actions = _run_sweep([_make_blender_bump_pr(20, "passing")])
+        assert len(actions) == 1
+        assert actions[0].action == "automerge"
+
+    def test_failing_blender_bump_dispatches_fix(self):
+        """Failing BLEnder bump PR -> dispatch fix."""
+        actions = _run_sweep([_make_blender_bump_pr(21, "failing")])
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_pending_blender_bump_skips(self):
+        """Pending BLEnder bump PR -> skip."""
+        actions = _run_sweep([_make_blender_bump_pr(22, "pending")])
+        assert actions == []
+
+    def test_wrong_author_not_picked_up(self):
+        """PR on blender/security-bump- branch but wrong author -> ignored."""
+        pr, status = _make_blender_bump_pr(23, "passing")
+        pr.user.login = "evil-user"
+        actions = _run_sweep([(pr, status)])
+        assert actions == []
+
+    def test_wrong_branch_not_picked_up(self):
+        """PR from BLEnder bot but wrong branch prefix -> ignored."""
+        pr, status = _make_blender_bump_pr(24, "passing")
+        pr.head.ref = "sneaky/security-bump-foo"
+        actions = _run_sweep([(pr, status)])
+        assert actions == []
 
 
 # --- CI-pending PRs ---


### PR DESCRIPTION
npm transitive deps live in `package-lock.json`, not `package.json`. The old code rejected npm bumps because it couldn't edit the lock file via the GitHub API alone. Now `post_alert_action.py` signals `action=npm_bump` to the workflow, which runs `npm update` in the target repo checkout and commits the result via `npm-bump.sh`.