### PR TITLE
feat: re-engage on major-bump PRs after code-owner approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @groovecoder

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -29,9 +29,9 @@ from github.Repository import Repository
 import nodesemver
 
 try:
-    from scripts.github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict
+    from scripts.github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict, has_codeowner_approval
 except ModuleNotFoundError:
-    from github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict
+    from github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict, has_codeowner_approval
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
@@ -638,7 +638,14 @@ def process_pr(
 
     meta = extract_metadata(pr)
 
-    gate_versions(meta, allow_major=config.allow_major)
+    # A code-owner approval after a BLEnder NEEDS_REVIEW verdict overrides
+    # the major-bump block.  The code owner said "go ahead", so we obey.
+    allow_major = config.allow_major
+    if not allow_major and has_blender_verdict(pr) and has_codeowner_approval(pr):
+        print("  Code owner approved after BLEnder review — allowing major bump.")
+        allow_major = True
+
+    gate_versions(meta, allow_major=allow_major)
     compat_score = gate_compatibility(pr, meta, config.min_compatibility_score)
     gate_ci(repo, pr.head.sha)
     gate_advisories(gh, meta)

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -28,6 +28,10 @@ from github.PullRequest import PullRequest
 from github.Repository import Repository
 import nodesemver
 
+# When run by pytest, the package root is on sys.path so
+# "scripts.github_utils" works.  When run directly (e.g. inside a
+# GitHub Actions step), only the scripts/ directory is on sys.path,
+# so the bare "github_utils" import is needed as a fallback.
 try:
     from scripts.github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict, has_codeowner_approval
 except ModuleNotFoundError:

--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -33,9 +33,19 @@ import nodesemver
 # GitHub Actions step), only the scripts/ directory is on sys.path,
 # so the bare "github_utils" import is needed as a fallback.
 try:
-    from scripts.github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict, has_codeowner_approval
+    from scripts.github_utils import (
+        BOT_LOGIN,
+        enable_auto_merge,
+        has_blender_verdict,
+        has_codeowner_approval,
+    )
 except ModuleNotFoundError:
-    from github_utils import BOT_LOGIN, enable_auto_merge, has_blender_verdict, has_codeowner_approval
+    from github_utils import (
+        BOT_LOGIN,
+        enable_auto_merge,
+        has_blender_verdict,
+        has_codeowner_approval,
+    )
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -15,12 +15,12 @@ class Verdict(Enum):
 
     The enum *name* (e.g. ``SAFE``) is the stable tag written at the
     start of every comment.  Dedup checks match on ``"SAFE:"``, so
-    changing a name is a breaking change.  The *value* is the human-
+    changing a name is a breaking change.  The *value* is the
     readable message that follows the tag.
     """
 
     SAFE = "major version bump is safe"
-    NEEDS_REVIEW = "this major version bump needs human review"
+    NEEDS_REVIEW = "this major version bump needs code-owner review"
     NO_VERDICT = "could not evaluate this major version bump"
     MALFORMED = "verdict file was malformed"
     APPROVED = "auto-merge: major bump evaluated as safe"
@@ -57,7 +57,7 @@ def has_blender_verdict(pr: PullRequest) -> bool:
 
 
 def has_codeowner_approval(pr: PullRequest) -> bool:
-    """True if a non-bot user approved this PR.
+    """True if a code owner approved this PR.
 
     Used to detect when a code owner overrides a BLEnder NEEDS_REVIEW
     verdict, signaling that the major bump should proceed.
@@ -67,6 +67,10 @@ def has_codeowner_approval(pr: PullRequest) -> bool:
     review (per the AI-in-dev policy), GitHub only counts approvals
     from designated code owners.  A non-bot APPROVED review on a
     protected branch therefore implies the reviewer is a code owner.
+
+    We filter out bot accounts (logins ending with ``[bot]``) because
+    GitHub App and bot accounts always follow the ``name[bot]``
+    convention — this is enforced by the platform, not a heuristic.
     """
     for review in pr.get_reviews():
         if review.state == "APPROVED" and not review.user.login.endswith("[bot]"):

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -56,6 +56,24 @@ def has_blender_verdict(pr: PullRequest) -> bool:
     return False
 
 
+def has_codeowner_approval(pr: PullRequest) -> bool:
+    """True if a non-bot user approved this PR.
+
+    Used to detect when a code owner overrides a BLEnder NEEDS_REVIEW
+    verdict, signaling that the major bump should proceed.
+
+    CODEOWNERS enforcement is handled by GitHub branch protection,
+    not here.  If the repo's branch protection requires code-owner
+    review (per the AI-in-dev policy), GitHub only counts approvals
+    from designated code owners.  A non-bot APPROVED review on a
+    protected branch therefore implies the reviewer is a code owner.
+    """
+    for review in pr.get_reviews():
+        if review.state == "APPROVED" and not review.user.login.endswith("[bot]"):
+            return True
+    return False
+
+
 def enable_auto_merge(pr: PullRequest) -> str | None:
     """Enable auto-merge on a PR via the GraphQL API.
 

--- a/scripts/post_major_review.py
+++ b/scripts/post_major_review.py
@@ -143,7 +143,7 @@ def main() -> None:
         )
         post_comment(pr, comment, dry_run)
         if not dry_run:
-            print("Posted analysis comment for human review.")
+            print("Posted analysis comment for code-owner review.")
 
 
 if __name__ == "__main__":

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -33,6 +33,13 @@ from github.GithubException import UnknownObjectException
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
+try:
+    from scripts.github_utils import has_codeowner_approval
+except ImportError:
+    from github_utils import has_codeowner_approval  # type: ignore[no-redef]
+
+BOT_LOGIN = "mozilla-blender[bot]"
+
 
 @dataclass
 class Action:
@@ -155,6 +162,12 @@ def process_repo(repo: Repository) -> list[Action]:
             continue
 
         if result == "fix":
+            # A code-owner approval overrides all "already tried" guards.
+            # This lets a code owner say "go ahead" and BLEnder retries.
+            codeowner_approved = has_codeowner_approval(pr)
+            if codeowner_approved:
+                print(f"    PR #{pr.number}: code owner approved — resetting fix guards")
+
             # Check for BLEnder commits on the PR.
             # Only bot commits with the "BLEnder fix(" prefix count.
             # Human commits use different messages and don't block dispatch.
@@ -162,7 +175,7 @@ def process_repo(repo: Repository) -> list[Action]:
             has_blender_commit = any(
                 (c.commit.message or "").startswith("BLEnder fix(") for c in commits
             )
-            if has_blender_commit:
+            if has_blender_commit and not codeowner_approved:
                 print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
                 continue
 
@@ -173,7 +186,7 @@ def process_repo(repo: Repository) -> list[Action]:
             latest_commit_date = max(
                 (c.commit.committer.date for c in commits), default=None
             )
-            if latest_commit_date is not None:
+            if latest_commit_date is not None and not codeowner_approved:
                 fix_comments = [
                     c
                     for c in pr.get_issue_comments()

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -166,7 +166,9 @@ def process_repo(repo: Repository) -> list[Action]:
             # This lets a code owner say "go ahead" and BLEnder retries.
             codeowner_approved = has_codeowner_approval(pr)
             if codeowner_approved:
-                print(f"    PR #{pr.number}: code owner approved — resetting fix guards")
+                print(
+                    f"    PR #{pr.number}: code owner approved — resetting fix guards"
+                )
 
             # Check for BLEnder commits on the PR.
             # Only bot commits with the "BLEnder fix(" prefix count.

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -170,7 +170,7 @@ def process_repo(repo: Repository) -> list[Action]:
 
             # Check for BLEnder commits on the PR.
             # Only bot commits with the "BLEnder fix(" prefix count.
-            # Human commits use different messages and don't block dispatch.
+            # Non-bot commits use different messages and don't block dispatch.
             commits = pr.get_commits()
             has_blender_commit = any(
                 (c.commit.message or "").startswith("BLEnder fix(") for c in commits
@@ -180,8 +180,8 @@ def process_repo(repo: Repository) -> list[Action]:
                 continue
 
             # Only skip if a bot fix-related comment was posted AFTER the
-            # latest commit.  Human comments are ignored (login must end
-            # with "[bot]").  Stale comments (before a force-push) are
+            # latest commit.  Non-bot comments are ignored (login must
+            # end with "[bot]").  Stale comments (before a force-push) are
             # also ignored so the fix can be retried on new code.
             latest_commit_date = max(
                 (c.commit.committer.date for c in commits), default=None

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -21,7 +21,7 @@ from scripts.automerge_dependabot import (
     main,
     version_in_range,
 )
-from scripts.github_utils import Verdict, has_blender_verdict
+from scripts.github_utils import Verdict, has_blender_verdict, has_codeowner_approval
 
 
 # --- _normalize_pep440_range ---
@@ -439,3 +439,113 @@ def test_main_no_comment_on_ci_failure(monkeypatch):
     pr = _make_dependabot_pr(number=99)
     _run_main(monkeypatch, pr, CIFailurePR("CI has 1 failure(s)"))
     pr.create_issue_comment.assert_not_called()
+
+
+# --- has_codeowner_approval ---
+
+
+def test_has_codeowner_approval_true():
+    pr = MagicMock()
+    review = MagicMock()
+    review.state = "APPROVED"
+    review.user.login = "joeherm"
+    pr.get_reviews.return_value = [review]
+    assert has_codeowner_approval(pr) is True
+
+
+def test_has_codeowner_approval_false_bot_only():
+    pr = MagicMock()
+    review = MagicMock()
+    review.state = "APPROVED"
+    review.user.login = "mozilla-blender[bot]"
+    pr.get_reviews.return_value = [review]
+    assert has_codeowner_approval(pr) is False
+
+
+def test_has_codeowner_approval_false_no_reviews():
+    pr = MagicMock()
+    pr.get_reviews.return_value = []
+    assert has_codeowner_approval(pr) is False
+
+
+def test_has_codeowner_approval_ignores_non_approval():
+    pr = MagicMock()
+    review = MagicMock()
+    review.state = "COMMENTED"
+    review.user.login = "joeherm"
+    pr.get_reviews.return_value = [review]
+    assert has_codeowner_approval(pr) is False
+
+
+# --- Code-owner approval overrides major bump in process_pr ---
+
+
+def test_process_pr_codeowner_approval_bypasses_major_gate():
+    """Code-owner approval + BLEnder verdict = allow_major, no MajorBumpPR raised."""
+    from scripts.automerge_dependabot import Config, process_pr
+
+    pr = MagicMock()
+    pr.number = 42
+    pr.title = "Bump eslint from 9.0.0 to 10.0.0"
+    pr.user.login = "dependabot[bot]"
+    pr.body = ""
+    pr.head.sha = "abc123"
+
+    # Verdict exists + human approved
+    verdict_comment = MagicMock()
+    verdict_comment.user.login = "mozilla-blender[bot]"
+    verdict_comment.body = Verdict.NEEDS_REVIEW.comment("Human review needed.")
+    pr.get_issue_comments.return_value = [verdict_comment]
+
+    human_review = MagicMock()
+    human_review.state = "APPROVED"
+    human_review.user.login = "joeherm"
+    pr.get_reviews.return_value = [human_review]
+
+    config = Config(
+        repo_name="owner/repo",
+        token="fake",
+        dry_run=True,
+        min_compatibility_score=70,
+        allow_major=False,
+    )
+    gh = MagicMock()
+    repo = MagicMock()
+
+    # Mock CI passing
+    commit_mock = MagicMock()
+    commit_mock.get_check_runs.return_value = []
+    combined = MagicMock()
+    combined.statuses = []
+    commit_mock.get_combined_status.return_value = combined
+    repo.get_commit.return_value = commit_mock
+
+    # Mock advisories clean
+    gh.get_global_advisories.return_value = []
+
+    # Without the code-owner approval fix, this would raise MajorBumpPR.
+    # With it, the major bump gate is skipped and process_pr succeeds.
+    with patch(
+        "scripts.automerge_dependabot.extract_metadata"
+    ) as mock_meta, patch(
+        "scripts.automerge_dependabot.gate_compatibility", return_value=None
+    ):
+        mock_meta.return_value = PRMetadata(
+            dependencies=[
+                DependencyUpdate(
+                    name="eslint",
+                    version="10.0.0",
+                    dependency_type="direct:development",
+                    update_type="version-update:semver-major",
+                    old_version="9.0.0",
+                )
+            ],
+            has_major=True,
+            old_version="9.0.0",
+            new_version="10.0.0",
+            ecosystem="npm",
+            raw_ecosystem="npm_and_yarn",
+        )
+        result = process_pr(config, gh, repo, pr)
+
+    assert result is True

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -402,7 +402,7 @@ def test_has_blender_verdict_false_when_no_verdict():
 def test_has_blender_verdict_ignores_human_comments():
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _gh_comment(body=Verdict.SAFE.comment("to merge."), login="groovecoder")
+        _gh_comment(body=Verdict.SAFE.comment("to merge."), login="some-codeowner")
     ]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is False
@@ -448,16 +448,16 @@ def test_has_codeowner_approval_true():
     pr = MagicMock()
     review = MagicMock()
     review.state = "APPROVED"
-    review.user.login = "joeherm"
+    review.user.login = "some-codeowner"
     pr.get_reviews.return_value = [review]
     assert has_codeowner_approval(pr) is True
 
 
-def test_has_codeowner_approval_false_bot_only():
+def test_has_codeowner_approval_returns_false_for_bots():
     pr = MagicMock()
     review = MagicMock()
     review.state = "APPROVED"
-    review.user.login = "mozilla-blender[bot]"
+    review.user.login = "some-app[bot]"
     pr.get_reviews.return_value = [review]
     assert has_codeowner_approval(pr) is False
 
@@ -472,35 +472,44 @@ def test_has_codeowner_approval_ignores_non_approval():
     pr = MagicMock()
     review = MagicMock()
     review.state = "COMMENTED"
-    review.user.login = "joeherm"
+    review.user.login = "some-codeowner"
     pr.get_reviews.return_value = [review]
     assert has_codeowner_approval(pr) is False
 
 
 # --- Code-owner approval overrides major bump in process_pr ---
+#
+# When BLEnder reviews a major-version Dependabot PR and leaves a
+# NEEDS_REVIEW verdict, the PR gets stuck: the automerge workflow
+# sees the verdict and skips it on every subsequent run.
+#
+# A code-owner approval should break this deadlock.  process_pr
+# checks for both a verdict and a code-owner approval; when both
+# exist, it sets allow_major=True so the version gate passes and
+# the PR proceeds through the remaining safety checks (CI,
+# compatibility, advisories).
 
 
 def test_process_pr_codeowner_approval_bypasses_major_gate():
     """Code-owner approval + BLEnder verdict = allow_major, no MajorBumpPR raised."""
     from scripts.automerge_dependabot import Config, process_pr
 
-    pr = MagicMock()
-    pr.number = 42
-    pr.title = "Bump eslint from 9.0.0 to 10.0.0"
-    pr.user.login = "dependabot[bot]"
+    codeowner_review = MagicMock()
+    codeowner_review.state = "APPROVED"
+    codeowner_review.user.login = "some-codeowner"
+
+    verdict_comment = _gh_comment(
+        body=Verdict.NEEDS_REVIEW.comment("Review needed.")
+    )
+
+    pr = _make_dependabot_pr(
+        number=42,
+        ref="dependabot/npm_and_yarn/eslint-10.0.0",
+        comments=[verdict_comment],
+        reviews=[codeowner_review],
+    )
     pr.body = ""
     pr.head.sha = "abc123"
-
-    # Verdict exists + human approved
-    verdict_comment = MagicMock()
-    verdict_comment.user.login = "mozilla-blender[bot]"
-    verdict_comment.body = Verdict.NEEDS_REVIEW.comment("Human review needed.")
-    pr.get_issue_comments.return_value = [verdict_comment]
-
-    human_review = MagicMock()
-    human_review.state = "APPROVED"
-    human_review.user.login = "joeherm"
-    pr.get_reviews.return_value = [human_review]
 
     config = Config(
         repo_name="owner/repo",

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -414,7 +414,7 @@ class TestCodeownerApprovalResetsFix:
             30,
             "failing",
             blender_commit=True,
-            reviews=[_make_review("joeherm")],
+            reviews=[_make_review("some-codeowner")],
         )
         actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
@@ -433,7 +433,7 @@ class TestCodeownerApprovalResetsFix:
                     T_LATE,
                 )
             ],
-            reviews=[_make_review("joeherm")],
+            reviews=[_make_review("some-codeowner")],
         )
         actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
@@ -445,7 +445,7 @@ class TestCodeownerApprovalResetsFix:
             32,
             "failing",
             blender_commit=True,
-            reviews=[_make_review("mozilla-blender[bot]")],
+            reviews=[_make_review("some-app[bot]")],
         )
         actions = _run_sweep([(pr, status)])
         assert actions == []

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -33,6 +33,14 @@ def _make_comment(login: str, body: str, created_at: datetime = T_EARLY):
     return c
 
 
+def _make_review(login: str, state: str = "APPROVED"):
+    """Build a mock PR review."""
+    r = MagicMock()
+    r.user.login = login
+    r.state = state
+    return r
+
+
 def _make_pr(
     number: int,
     ci_status: str,
@@ -40,6 +48,7 @@ def _make_pr(
     commits: list | None = None,
     blender_commit: bool = False,
     is_dependabot: bool = True,
+    reviews: list | None = None,
 ):
     """Build a mock PR with configurable CI, comments, and commits.
 
@@ -59,6 +68,7 @@ def _make_pr(
         commit_list.append(_make_commit("Bump foo from 1.0.0 to 2.0.0"))
     pr.get_commits.return_value = commit_list
     pr.get_issue_comments.return_value = list(comments or [])
+    pr.get_reviews.return_value = list(reviews or [])
 
     return pr, ci_status
 
@@ -391,4 +401,51 @@ class TestAlertDiscovery:
         repo.get_branches.return_value = []
 
         actions = check_alerts(repo)
+        assert actions == []
+
+
+# --- Code-owner approval resets fix guards ---
+
+
+class TestCodeownerApprovalResetsFix:
+    def test_codeowner_approval_overrides_blender_commit(self):
+        """Code owner approved + BLEnder commit -> dispatch fix anyway."""
+        pr, status = _make_pr(
+            30,
+            "failing",
+            blender_commit=True,
+            reviews=[_make_review("joeherm")],
+        )
+        actions = _run_sweep([(pr, status)])
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_codeowner_approval_overrides_fresh_fix_comment(self):
+        """Code owner approved + fresh 'could not fix' comment -> dispatch fix."""
+        pr, status = _make_pr(
+            31,
+            "failing",
+            commits=[_make_commit("Bump foo", T_EARLY)],
+            comments=[
+                _make_comment(
+                    "blender[bot]",
+                    "BLEnder could not fix this PR automatically.",
+                    T_LATE,
+                )
+            ],
+            reviews=[_make_review("joeherm")],
+        )
+        actions = _run_sweep([(pr, status)])
+        assert len(actions) == 1
+        assert actions[0].action == "fix"
+
+    def test_bot_approval_does_not_override(self):
+        """Bot approval + BLEnder commit -> still skip."""
+        pr, status = _make_pr(
+            32,
+            "failing",
+            blender_commit=True,
+            reviews=[_make_review("mozilla-blender[bot]")],
+        )
+        actions = _run_sweep([(pr, status)])
         assert actions == []


### PR DESCRIPTION
When a code owner approves a Dependabot PR that BLEnder previously flagged as NEEDS_REVIEW, BLEnder now treats it as actionable again.

Automerge path (CI green): code-owner approval overrides the major-bump gate, letting the PR proceed through remaining safety checks and merge.

Sweep/fix path (CI red): code-owner approval resets the "already tried" fix guards, so the fix workflow re-dispatches.

Also adds .github/CODEOWNERS (@groovecoder for full repo).