### PR TITLE
Fix remediation for transitive pip dependency alerts

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -204,6 +204,51 @@ jobs:
           REPO: ${{ inputs.target_repo }}
           GH_TOKEN: ${{ steps.setup.outputs.token }}
 
+      # --- pip transitive dependency bump (lock file only) ---
+      - name: Run pip lock upgrade
+        id: pip-fix
+        if: steps.post-action.outputs.action == 'pip_lock_bump'
+        working-directory: target
+        run: |
+          echo "Upgrading ${PIP_PACKAGE} via ${PIP_LOCK_TOOL}..."
+          case "$PIP_LOCK_TOOL" in
+            uv)
+              pip install uv
+              uv lock --upgrade-package "$PIP_PACKAGE"
+              ;;
+            poetry)
+              pip install poetry
+              poetry update "$PIP_PACKAGE"
+              ;;
+            pipenv)
+              pip install pipenv
+              pipenv update "$PIP_PACKAGE"
+              ;;
+            *)
+              echo "Unknown lock tool: ${PIP_LOCK_TOOL}"
+              exit 1
+              ;;
+          esac
+          echo "upgraded=true" >> "$GITHUB_OUTPUT"
+        env:
+          PIP_PACKAGE: ${{ steps.post-action.outputs.pip_package }}
+          PIP_LOCK_TOOL: ${{ steps.post-action.outputs.pip_lock_tool }}
+
+      - name: Create pip bump PR
+        if: >-
+          steps.post-action.outputs.action == 'pip_lock_bump'
+          && steps.pip-fix.outputs.upgraded == 'true'
+          && inputs.dry_run != 'true'
+        working-directory: target
+        run: bash ${{ github.workspace }}/scripts/pip-lock-bump.sh
+        env:
+          PACKAGE: ${{ steps.post-action.outputs.pip_package }}
+          PATCHED_VERSION: ${{ steps.post-action.outputs.pip_version }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+          REPO: ${{ inputs.target_repo }}
+          GH_TOKEN: ${{ steps.setup.outputs.token }}
+          PIP_LOCK_TOOL: ${{ steps.post-action.outputs.pip_lock_tool }}
+
       # --- Private fork remediation (only for affected alerts) ---
       - name: Clone private fork
         if: steps.post-action.outputs.action == 'private_fork'

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -35,6 +35,7 @@ def render_markdown(
         "existing_pr": "Existing Dependabot PR found",
         "bump_pr_created": "Bump PR created",
         "npm_bump": "npm bump PR created",
+        "dependabot_requested": "Dependabot security update requested",
     }
     action_text = action_labels.get(action, action)
 
@@ -80,6 +81,7 @@ def annotation_line(
         "noop": "no action taken",
         "private_fork": "advisory created with private fork",
         "npm_bump": "npm bump PR created",
+        "dependabot_requested": "Dependabot security update requested",
     }
     action_text = action_labels.get(action, action)
 

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -35,7 +35,7 @@ def render_markdown(
         "existing_pr": "Existing Dependabot PR found",
         "bump_pr_created": "Bump PR created",
         "npm_bump": "npm bump PR created",
-        "dependabot_requested": "Dependabot security update requested",
+        "pip_lock_bump": "pip lock bump PR created",
     }
     action_text = action_labels.get(action, action)
 
@@ -81,7 +81,7 @@ def annotation_line(
         "noop": "no action taken",
         "private_fork": "advisory created with private fork",
         "npm_bump": "npm bump PR created",
-        "dependabot_requested": "Dependabot security update requested",
+        "pip_lock_bump": "pip lock bump PR created",
     }
     action_text = action_labels.get(action, action)
 

--- a/scripts/extract_alert_verdict.py
+++ b/scripts/extract_alert_verdict.py
@@ -15,10 +15,31 @@ import sys
 VERDICT_FILE = ".blender-alert-verdict.json"
 
 
-def extract(log: str) -> dict | None:
-    """Try to extract verdict JSON from Claude's output text."""
+def _extract_text_from_json_log(log: str) -> str:
+    """Extract assistant text from --output-format json session logs."""
+    try:
+        events = json.loads(log)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+
+    if not isinstance(events, list):
+        return ""
+
+    parts = []
+    for event in events:
+        msg = event.get("message") if isinstance(event, dict) else None
+        if not msg or msg.get("role") != "assistant":
+            continue
+        for block in msg.get("content", []):
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block["text"])
+    return "\n".join(parts)
+
+
+def _search_text(text: str) -> dict | None:
+    """Search plain text for a VERDICT_JSON block or bare verdict object."""
     # Primary: look for ```VERDICT_JSON ... ``` fenced block
-    m = re.search(r"```VERDICT_JSON\s*\n(.*?)\n\s*```", log, re.DOTALL)
+    m = re.search(r"```VERDICT_JSON\s*\n(.*?)\n\s*```", text, re.DOTALL)
     if m:
         try:
             obj = json.loads(m.group(1))
@@ -28,7 +49,7 @@ def extract(log: str) -> dict | None:
             print(f"VERDICT_JSON block found but invalid JSON: {e}", file=sys.stderr)
 
     # Fallback: any JSON object containing "affected" key
-    for m2 in re.finditer(r"\{[^{}]*\"affected\"[^{}]*\}", log, re.DOTALL):
+    for m2 in re.finditer(r"\{[^{}]*\"affected\"[^{}]*\}", text, re.DOTALL):
         try:
             obj = json.loads(m2.group())
             if "affected" in obj and "reason" in obj:
@@ -36,6 +57,25 @@ def extract(log: str) -> dict | None:
                 return obj
         except json.JSONDecodeError:
             continue
+
+    return None
+
+
+def extract(log: str) -> dict | None:
+    """Try to extract verdict JSON from Claude's output text.
+
+    Handles both plain-text output (-p) and JSON session logs
+    (--output-format json) produced when CLAUDE_VERBOSE=true.
+    """
+    # Try plain text first (non-verbose mode)
+    result = _search_text(log)
+    if result:
+        return result
+
+    # Try JSON session log (verbose mode)
+    text = _extract_text_from_json_log(log)
+    if text:
+        return _search_text(text)
 
     return None
 

--- a/scripts/pip-lock-bump.sh
+++ b/scripts/pip-lock-bump.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# BLEnder pip lock bump: upgrade a transitive pip dependency via the
+# repo's lock tool, commit changed lock files via verified commit,
+# and open a PR.
+#
+# Runs after the lock tool upgrade in the target repo checkout.
+# Delegates blob -> tree -> commit to git-commit-api.sh.
+#
+# Environment variables:
+#   GH_TOKEN          -- GitHub token (required, also used for gh cli)
+#   PACKAGE           -- pip package name (required)
+#   PATCHED_VERSION   -- version to bump to (required)
+#   ALERT_NUMBER      -- Dependabot alert number (required)
+#   REPO              -- target repo, e.g. mozilla/fx-private-relay (required)
+#   PIP_LOCK_TOOL     -- lock tool name: uv, poetry, or pipenv (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "Error: GH_TOKEN and REPO are required."
+  exit 1
+fi
+
+if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
+  echo "Error: PACKAGE and ALERT_NUMBER are required."
+  exit 1
+fi
+
+if [ -z "${PIP_LOCK_TOOL:-}" ]; then
+  echo "Error: PIP_LOCK_TOOL is required."
+  exit 1
+fi
+
+# Determine which lock files to check based on tool
+case "$PIP_LOCK_TOOL" in
+  uv)      LOCK_FILES=("uv.lock") ;;
+  poetry)  LOCK_FILES=("poetry.lock") ;;
+  pipenv)  LOCK_FILES=("Pipfile.lock") ;;
+  *)
+    echo "Unknown pip lock tool: ${PIP_LOCK_TOOL}"
+    exit 1
+    ;;
+esac
+
+# Check that at least one lock file changed
+CHANGED_FILES=()
+for file in "${LOCK_FILES[@]}"; do
+  if ! git diff --quiet "$file" 2>/dev/null; then
+    CHANGED_FILES+=("$file")
+  fi
+done
+
+if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+  echo "No lock files changed after ${PIP_LOCK_TOOL} upgrade. Nothing to do."
+  exit 0
+fi
+
+BRANCH_NAME="blender/security-bump-${PACKAGE}"
+
+# Check for existing open PR on this branch
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
+  exit 0
+fi
+
+COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+
+Resolves Dependabot alert #${ALERT_NUMBER}.
+Created by BLEnder (https://github.com/mozilla/blender)"
+
+DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
+PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+
+COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
+
+# Create branch ref
+gh api "repos/${REPO}/git/refs" \
+  --method POST \
+  --field "ref=refs/heads/${BRANCH_NAME}" \
+  --field "sha=${COMMIT_SHA}" || {
+    echo "Branch ${BRANCH_NAME} already exists. Updating."
+    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
+      --method PATCH \
+      --field "sha=${COMMIT_SHA}"
+  }
+
+echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
+
+# Build PR body
+SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+if [ -n "$RUN_ID" ]; then
+  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
+else
+  RUN_LINK="BLEnder investigation"
+fi
+
+PR_BODY="## Summary
+
+Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER}).
+
+This is a transitive dependency update via \`${PIP_LOCK_TOOL}\`. Only lock files changed.
+
+---
+*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
+
+PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
+
+gh pr create \
+  --repo "$REPO" \
+  --head "$BRANCH_NAME" \
+  --base "$DEFAULT_BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY"
+
+echo "PR created."

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -232,6 +232,16 @@ def find_dependency_pin(
             except Exception:
                 continue
 
+        # Also check pyproject.toml [project.dependencies] and optional-deps
+        try:
+            file_content = repo.get_contents("pyproject.toml")
+            text = file_content.decoded_content.decode("utf-8")
+            if pin_pattern.search(text):
+                print(f"  Found {package_name} pin in pyproject.toml")
+                return ("pyproject.toml", text, file_content.sha)
+        except Exception:
+            pass
+
     elif ecosystem == "npm":
         try:
             file_content = repo.get_contents("package.json")
@@ -349,6 +359,42 @@ def create_bump_pr(
         return None
 
 
+def request_dependabot_update(
+    repo,
+    alert_number: int,
+    package_name: str,
+    dry_run: bool,
+) -> str | None:
+    """Ask GitHub to create a Dependabot security update for this alert.
+
+    Ensures automated security fixes are enabled on the repo, then
+    returns 'dependabot_requested' on success or None on failure.
+    """
+    fixes_url = f"/repos/{repo.full_name}/automated-security-fixes"
+
+    if dry_run:
+        print("  DRY_RUN: would enable automated security fixes")
+        return "dependabot_requested"
+
+    try:
+        repo._requester.requestJsonAndCheck("PUT", fixes_url)
+        print(f"  Enabled automated security fixes for {repo.full_name}")
+    except Exception as e:
+        error_str = str(e)
+        # 409 means already enabled — that's fine
+        if "409" in error_str or "already enabled" in error_str.lower():
+            print("  Automated security fixes already enabled.")
+        else:
+            print(f"  Could not enable automated security fixes: {e}")
+            return None
+
+    print(
+        f"  Dependabot will create a security update for {package_name}"
+        f" (alert #{alert_number}) if it can resolve the dependency."
+    )
+    return "dependabot_requested"
+
+
 def dismiss_alert(
     repo,
     alert_number: int,
@@ -442,7 +488,12 @@ def main() -> None:
                     if pr_num > 0:
                         write_output("bump_pr_number", str(pr_num))
                 else:
-                    action = "noop"
+                    # No direct pin found — ask Dependabot to handle it
+                    print("  Falling back to Dependabot security update.")
+                    result = request_dependabot_update(
+                        repo, alert_number, package_name, dry_run
+                    )
+                    action = result or "noop"
         elif dismiss_enabled and severity.lower() not in DISMISS_BLOCKED_SEVERITIES:
             print("  Unaffected + dismiss enabled. Dismissing alert.")
             dismiss_alert(repo, alert_number, reason, dry_run)

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -359,6 +359,22 @@ def create_bump_pr(
         return None
 
 
+def fetch_patched_version(repo, alert_number: int) -> str:
+    """Fetch the patched version from the Dependabot alert API."""
+    url = f"/repos/{repo.full_name}/dependabot/alerts/{alert_number}"
+    try:
+        _, data = repo._requester.requestJsonAndCheck("GET", url)
+        vuln = data.get("security_vulnerability", {})
+        patched = vuln.get("first_patched_version") or {}
+        version = patched.get("identifier", "")
+        if version:
+            print(f"  Fetched patched version from alert: {version}")
+        return version
+    except Exception as e:
+        print(f"  Could not fetch patched version: {e}")
+        return ""
+
+
 def detect_pip_lock_tool(
     repo,
 ) -> tuple[str, str] | None:
@@ -428,6 +444,10 @@ def main() -> None:
 
     g = Github(auth=Auth.Token(token))
     repo = g.get_repo(repo_name)
+
+    # Fetch patched version from the alert API if not provided
+    if not patched_version and alert_number:
+        patched_version = fetch_patched_version(repo, alert_number)
 
     verdict = load_verdict()
     if verdict is None:

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -4,7 +4,7 @@
 Reads .blender-alert-verdict.json and takes the appropriate action:
 
   unaffected + existing PR       -> comment on the PR, let other workflows handle
-  unaffected + no PR             -> trigger Dependabot security update
+  unaffected + no PR             -> bump via lock tool or create PR
   unaffected + dismiss enabled   -> dismiss the alert (low/medium only)
   affected                       -> create advisory with private fork
 
@@ -359,40 +359,27 @@ def create_bump_pr(
         return None
 
 
-def request_dependabot_update(
+def detect_pip_lock_tool(
     repo,
-    alert_number: int,
-    package_name: str,
-    dry_run: bool,
-) -> str | None:
-    """Ask GitHub to create a Dependabot security update for this alert.
+) -> tuple[str, str] | None:
+    """Detect which pip lock tool the repo uses.
 
-    Ensures automated security fixes are enabled on the repo, then
-    returns 'dependabot_requested' on success or None on failure.
+    Checks for lock files in order of preference and returns
+    (tool_name, command_template) or None if no lock file found.
     """
-    fixes_url = f"/repos/{repo.full_name}/automated-security-fixes"
-
-    if dry_run:
-        print("  DRY_RUN: would enable automated security fixes")
-        return "dependabot_requested"
-
-    try:
-        repo._requester.requestJsonAndCheck("PUT", fixes_url)
-        print(f"  Enabled automated security fixes for {repo.full_name}")
-    except Exception as e:
-        error_str = str(e)
-        # 409 means already enabled — that's fine
-        if "409" in error_str or "already enabled" in error_str.lower():
-            print("  Automated security fixes already enabled.")
-        else:
-            print(f"  Could not enable automated security fixes: {e}")
-            return None
-
-    print(
-        f"  Dependabot will create a security update for {package_name}"
-        f" (alert #{alert_number}) if it can resolve the dependency."
-    )
-    return "dependabot_requested"
+    lock_files = {
+        "uv.lock": ("uv", "uv lock --upgrade-package {pkg}"),
+        "poetry.lock": ("poetry", "poetry update {pkg}"),
+        "Pipfile.lock": ("pipenv", "pipenv update {pkg}"),
+    }
+    for lock_file, (tool, cmd) in lock_files.items():
+        try:
+            repo.get_contents(lock_file)
+            print(f"  Found {lock_file} — using {tool}")
+            return (tool, cmd)
+        except Exception:
+            continue
+    return None
 
 
 def dismiss_alert(
@@ -488,12 +475,22 @@ def main() -> None:
                     if pr_num > 0:
                         write_output("bump_pr_number", str(pr_num))
                 else:
-                    # No direct pin found — ask Dependabot to handle it
-                    print("  Falling back to Dependabot security update.")
-                    result = request_dependabot_update(
-                        repo, alert_number, package_name, dry_run
-                    )
-                    action = result or "noop"
+                    # No direct pin — try lock file upgrade
+                    if ecosystem == "pip" and patched_version:
+                        lock_tool = detect_pip_lock_tool(repo)
+                        if lock_tool:
+                            tool_name, _ = lock_tool
+                            print(f"  Lock tool detected: {tool_name}")
+                            action = "pip_lock_bump"
+                            write_output("pip_package", package_name)
+                            write_output("pip_version", patched_version)
+                            write_output("pip_lock_tool", tool_name)
+                            write_output("alert_number", str(alert_number))
+                        else:
+                            print("  No direct pin or lock tool. No action.")
+                            action = "noop"
+                    else:
+                        action = "noop"
         elif dismiss_enabled and severity.lower() not in DISMISS_BLOCKED_SEVERITIES:
             print("  Unaffected + dismiss enabled. Dismissing alert.")
             dismiss_alert(repo, alert_number, reason, dry_run)

--- a/tests/scripts/test_extract_alert_verdict.py
+++ b/tests/scripts/test_extract_alert_verdict.py
@@ -1,0 +1,58 @@
+"""Tests for scripts.extract_alert_verdict."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.extract_alert_verdict import extract
+
+
+VERDICT = {
+    "affected": False,
+    "confidence": "high",
+    "reason": "not used",
+    "vulnerable_paths": [],
+    "recommended_action": "bump_pr",
+}
+
+
+def test_plain_text_verdict_json_block():
+    log = "Some preamble\n```VERDICT_JSON\n" + json.dumps(VERDICT, indent=2) + "\n```\n"
+    assert extract(log) == VERDICT
+
+
+def test_plain_text_fallback_bare_object():
+    log = "Analysis complete. " + json.dumps(VERDICT)
+    assert extract(log) == VERDICT
+
+
+def test_json_session_log():
+    """--output-format json wraps text in a JSON event array."""
+    events = [
+        {"type": "system", "subtype": "init"},
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "Here is my verdict:\n\n"
+                            "```VERDICT_JSON\n"
+                            + json.dumps(VERDICT, indent=2)
+                            + "\n```"
+                        ),
+                    }
+                ],
+            },
+        },
+        {"type": "result", "subtype": "success"},
+    ]
+    log = json.dumps(events)
+    assert extract(log) == VERDICT
+
+
+def test_no_verdict_returns_none():
+    assert extract("No verdict here.") is None
+    assert extract("[]") is None

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -16,12 +16,12 @@ from scripts.alert_report import (
 from scripts.post_alert_action import (
     create_advisory_and_fork,
     create_bump_pr,
+    detect_pip_lock_tool,
     dismiss_alert,
     find_dependency_pin,
     find_existing_bump_pr,
     load_verdict,
     main,
-    request_dependabot_update,
 )
 
 
@@ -383,48 +383,97 @@ class TestMainFlow:
         assert "action=noop" in outputs
 
 
-class TestRequestDependabotUpdate:
-    def test_dry_run_skips(self):
+class TestDetectPipLockTool:
+    def test_uv_lock_detected(self):
         repo = MagicMock()
-        result = request_dependabot_update(repo, 42, "idna", dry_run=True)
-        assert result == "dependabot_requested"
-        repo._requester.requestJsonAndCheck.assert_not_called()
+        repo.get_contents.return_value = MagicMock()
+        result = detect_pip_lock_tool(repo)
+        assert result is not None
+        tool, cmd = result
+        assert tool == "uv"
+        assert "uv lock" in cmd
+        repo.get_contents.assert_called_once_with("uv.lock")
 
-    def test_enables_automated_fixes(self):
+    def test_poetry_lock_detected(self):
         repo = MagicMock()
-        repo.full_name = "owner/repo"
-        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
-        assert result == "dependabot_requested"
-        repo._requester.requestJsonAndCheck.assert_called_once_with(
-            "PUT", "/repos/owner/repo/automated-security-fixes"
-        )
+        repo.get_contents.side_effect = [Exception("404"), MagicMock()]
+        result = detect_pip_lock_tool(repo)
+        assert result is not None
+        assert result[0] == "poetry"
 
-    def test_already_enabled_succeeds(self):
+    def test_pipfile_lock_detected(self):
         repo = MagicMock()
-        repo.full_name = "owner/repo"
-        repo._requester.requestJsonAndCheck.side_effect = Exception("409 Conflict")
-        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
-        assert result == "dependabot_requested"
+        repo.get_contents.side_effect = [
+            Exception("404"),
+            Exception("404"),
+            MagicMock(),
+        ]
+        result = detect_pip_lock_tool(repo)
+        assert result is not None
+        assert result[0] == "pipenv"
 
-    def test_api_failure_returns_none(self):
+    def test_no_lock_file(self):
         repo = MagicMock()
-        repo.full_name = "owner/repo"
-        repo._requester.requestJsonAndCheck.side_effect = Exception("500 Server Error")
-        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
-        assert result is None
+        repo.get_contents.side_effect = Exception("404")
+        assert detect_pip_lock_tool(repo) is None
 
 
-class TestFallbackToDependabot:
-    """Integration: pip transitive dep with no pin falls back to Dependabot."""
+class TestPipLockBumpFlow:
+    """Integration: pip transitive dep with no pin triggers lock bump."""
 
-    def test_pip_no_pin_requests_dependabot(
+    def test_pip_no_pin_with_uv_lock(
         self, verdict_file, tmp_path, monkeypatch
     ):
         verdict_file(SAMPLE_VERDICT)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
         mock_repo.get_pulls.return_value = []
-        # get_contents raises for every file — no pin found
+
+        def get_contents_side_effect(path):
+            if path == "uv.lock":
+                return MagicMock()
+            raise Exception("404 Not Found")
+
+        mock_repo.get_contents.side_effect = get_contents_side_effect
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        summary_file = str(tmp_path / "step-summary.md")
+        for k, v in {
+            "GH_TOKEN": "fake",
+            "REPO": "owner/repo",
+            "ALERT_NUMBER": "2",
+            "ALERT_PACKAGE": "idna",
+            "ALERT_ECOSYSTEM": "pip",
+            "ALERT_SEVERITY": "high",
+            "ALERT_PATCHED_VERSION": "3.15",
+            "DRY_RUN": "false",
+            "DISMISS_UNAFFECTED": "false",
+            "GITHUB_STEP_SUMMARY": summary_file,
+            "GITHUB_OUTPUT": output_file,
+        }.items():
+            monkeypatch.setenv(k, v)
+
+        with patch("scripts.post_alert_action.Github") as mock_gh:
+            mock_gh.return_value.get_repo.return_value = mock_repo
+            main()
+
+        outputs = open(output_file).read()
+        assert "action=pip_lock_bump" in outputs
+        assert "pip_package=idna" in outputs
+        assert "pip_version=3.15" in outputs
+        assert "pip_lock_tool=uv" in outputs
+        content = open(summary_file).read()
+        assert "pip lock bump" in content.lower()
+
+    def test_pip_no_pin_no_lock_noop(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        verdict_file(SAMPLE_VERDICT)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
         mock_repo.get_contents.side_effect = Exception("404 Not Found")
 
         output_file = str(tmp_path / "github_output")
@@ -451,6 +500,4 @@ class TestFallbackToDependabot:
             main()
 
         outputs = open(output_file).read()
-        assert "action=dependabot_requested" in outputs
-        content = open(summary_file).read()
-        assert "Dependabot security update requested" in content
+        assert "action=noop" in outputs

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -416,47 +416,72 @@ class TestFetchPatchedVersion:
 
 
 class TestDetectPipLockTool:
-    def test_uv_lock_detected(self):
-        repo = MagicMock()
-        repo.get_contents.return_value = MagicMock()
-        result = detect_pip_lock_tool(repo)
-        assert result is not None
-        tool, cmd = result
-        assert tool == "uv"
-        assert "uv lock" in cmd
-        repo.get_contents.assert_called_once_with("uv.lock")
+    """detect_pip_lock_tool checks files in order: uv.lock, poetry.lock, Pipfile.lock."""
 
-    def test_poetry_lock_detected(self):
+    @pytest.mark.parametrize(
+        "files_present, expected_tool",
+        [
+            ({"uv.lock"}, "uv"),
+            ({"poetry.lock"}, "poetry"),
+            ({"Pipfile.lock"}, "pipenv"),
+            ({"uv.lock", "poetry.lock"}, "uv"),  # uv wins when both exist
+            (set(), None),
+        ],
+        ids=["uv", "poetry", "pipenv", "uv-wins-over-poetry", "none"],
+    )
+    def test_lock_tool_detection(self, files_present, expected_tool):
         repo = MagicMock()
-        repo.get_contents.side_effect = [Exception("404"), MagicMock()]
-        result = detect_pip_lock_tool(repo)
-        assert result is not None
-        assert result[0] == "poetry"
 
-    def test_pipfile_lock_detected(self):
-        repo = MagicMock()
-        repo.get_contents.side_effect = [
-            Exception("404"),
-            Exception("404"),
-            MagicMock(),
-        ]
-        result = detect_pip_lock_tool(repo)
-        assert result is not None
-        assert result[0] == "pipenv"
+        def get_contents(path):
+            if path in files_present:
+                return MagicMock()
+            raise Exception("404")
 
-    def test_no_lock_file(self):
-        repo = MagicMock()
-        repo.get_contents.side_effect = Exception("404")
-        assert detect_pip_lock_tool(repo) is None
+        repo.get_contents.side_effect = get_contents
+
+        result = detect_pip_lock_tool(repo)
+        if expected_tool is None:
+            assert result is None
+        else:
+            assert result is not None
+            assert result[0] == expected_tool
 
 
 class TestPipLockBumpFlow:
     """Integration: pip transitive dep with no pin triggers lock bump."""
 
+    def _run_pip_main(self, verdict_file, tmp_path, monkeypatch, mock_repo):
+        """Run main() with pip ecosystem defaults. Returns (outputs, summary)."""
+        verdict_file(SAMPLE_VERDICT)
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+        summary_file = str(tmp_path / "step-summary.md")
+
+        for k, v in {
+            "GH_TOKEN": "fake",
+            "REPO": "owner/repo",
+            "ALERT_NUMBER": "2",
+            "ALERT_PACKAGE": "idna",
+            "ALERT_ECOSYSTEM": "pip",
+            "ALERT_SEVERITY": "high",
+            "ALERT_PATCHED_VERSION": "3.15",
+            "DRY_RUN": "false",
+            "DISMISS_UNAFFECTED": "false",
+            "GITHUB_STEP_SUMMARY": summary_file,
+            "GITHUB_OUTPUT": output_file,
+        }.items():
+            monkeypatch.setenv(k, v)
+
+        with patch("scripts.post_alert_action.Github") as mock_gh:
+            mock_gh.return_value.get_repo.return_value = mock_repo
+            main()
+
+        return open(output_file).read(), open(summary_file).read()
+
     def test_pip_no_pin_with_uv_lock(
         self, verdict_file, tmp_path, monkeypatch
     ):
-        verdict_file(SAMPLE_VERDICT)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
         mock_repo.get_pulls.return_value = []
@@ -468,68 +493,24 @@ class TestPipLockBumpFlow:
 
         mock_repo.get_contents.side_effect = get_contents_side_effect
 
-        output_file = str(tmp_path / "github_output")
-        open(output_file, "w").close()
-
-        summary_file = str(tmp_path / "step-summary.md")
-        for k, v in {
-            "GH_TOKEN": "fake",
-            "REPO": "owner/repo",
-            "ALERT_NUMBER": "2",
-            "ALERT_PACKAGE": "idna",
-            "ALERT_ECOSYSTEM": "pip",
-            "ALERT_SEVERITY": "high",
-            "ALERT_PATCHED_VERSION": "3.15",
-            "DRY_RUN": "false",
-            "DISMISS_UNAFFECTED": "false",
-            "GITHUB_STEP_SUMMARY": summary_file,
-            "GITHUB_OUTPUT": output_file,
-        }.items():
-            monkeypatch.setenv(k, v)
-
-        with patch("scripts.post_alert_action.Github") as mock_gh:
-            mock_gh.return_value.get_repo.return_value = mock_repo
-            main()
-
-        outputs = open(output_file).read()
+        outputs, summary = self._run_pip_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo
+        )
         assert "action=pip_lock_bump" in outputs
         assert "pip_package=idna" in outputs
         assert "pip_version=3.15" in outputs
         assert "pip_lock_tool=uv" in outputs
-        content = open(summary_file).read()
-        assert "pip lock bump" in content.lower()
+        assert "pip lock bump" in summary.lower()
 
     def test_pip_no_pin_no_lock_noop(
         self, verdict_file, tmp_path, monkeypatch
     ):
-        verdict_file(SAMPLE_VERDICT)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
         mock_repo.get_pulls.return_value = []
         mock_repo.get_contents.side_effect = Exception("404 Not Found")
 
-        output_file = str(tmp_path / "github_output")
-        open(output_file, "w").close()
-
-        summary_file = str(tmp_path / "step-summary.md")
-        for k, v in {
-            "GH_TOKEN": "fake",
-            "REPO": "owner/repo",
-            "ALERT_NUMBER": "2",
-            "ALERT_PACKAGE": "idna",
-            "ALERT_ECOSYSTEM": "pip",
-            "ALERT_SEVERITY": "high",
-            "ALERT_PATCHED_VERSION": "3.15",
-            "DRY_RUN": "false",
-            "DISMISS_UNAFFECTED": "false",
-            "GITHUB_STEP_SUMMARY": summary_file,
-            "GITHUB_OUTPUT": output_file,
-        }.items():
-            monkeypatch.setenv(k, v)
-
-        with patch("scripts.post_alert_action.Github") as mock_gh:
-            mock_gh.return_value.get_repo.return_value = mock_repo
-            main()
-
-        outputs = open(output_file).read()
+        outputs, _ = self._run_pip_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo
+        )
         assert "action=noop" in outputs

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -18,6 +18,7 @@ from scripts.post_alert_action import (
     create_bump_pr,
     detect_pip_lock_tool,
     dismiss_alert,
+    fetch_patched_version,
     find_dependency_pin,
     find_existing_bump_pr,
     load_verdict,
@@ -174,6 +175,7 @@ class TestMainFlow:
             "ALERT_PACKAGE": "lodash",
             "ALERT_ECOSYSTEM": "npm",
             "ALERT_SEVERITY": "low",
+            "ALERT_PATCHED_VERSION": "1.0.0",
             "DISMISS_UNAFFECTED": "false",
             "DRY_RUN": "false",
             "GITHUB_STEP_SUMMARY": summary_file,
@@ -381,6 +383,36 @@ class TestMainFlow:
 
         outputs = open(output_file).read()
         assert "action=noop" in outputs
+
+
+class TestFetchPatchedVersion:
+    def test_fetches_from_api(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo._requester.requestJsonAndCheck.return_value = (
+            None,
+            {
+                "security_vulnerability": {
+                    "first_patched_version": {"identifier": "3.15"},
+                }
+            },
+        )
+        assert fetch_patched_version(repo, 2) == "3.15"
+
+    def test_returns_empty_on_api_error(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo._requester.requestJsonAndCheck.side_effect = Exception("403")
+        assert fetch_patched_version(repo, 2) == ""
+
+    def test_returns_empty_when_no_patched_version(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo._requester.requestJsonAndCheck.return_value = (
+            None,
+            {"security_vulnerability": {}},
+        )
+        assert fetch_patched_version(repo, 2) == ""
 
 
 class TestDetectPipLockTool:

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -21,6 +21,7 @@ from scripts.post_alert_action import (
     find_existing_bump_pr,
     load_verdict,
     main,
+    request_dependabot_update,
 )
 
 
@@ -380,3 +381,76 @@ class TestMainFlow:
 
         outputs = open(output_file).read()
         assert "action=noop" in outputs
+
+
+class TestRequestDependabotUpdate:
+    def test_dry_run_skips(self):
+        repo = MagicMock()
+        result = request_dependabot_update(repo, 42, "idna", dry_run=True)
+        assert result == "dependabot_requested"
+        repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_enables_automated_fixes(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
+        assert result == "dependabot_requested"
+        repo._requester.requestJsonAndCheck.assert_called_once_with(
+            "PUT", "/repos/owner/repo/automated-security-fixes"
+        )
+
+    def test_already_enabled_succeeds(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo._requester.requestJsonAndCheck.side_effect = Exception("409 Conflict")
+        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
+        assert result == "dependabot_requested"
+
+    def test_api_failure_returns_none(self):
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        repo._requester.requestJsonAndCheck.side_effect = Exception("500 Server Error")
+        result = request_dependabot_update(repo, 42, "idna", dry_run=False)
+        assert result is None
+
+
+class TestFallbackToDependabot:
+    """Integration: pip transitive dep with no pin falls back to Dependabot."""
+
+    def test_pip_no_pin_requests_dependabot(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        verdict_file(SAMPLE_VERDICT)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+        # get_contents raises for every file — no pin found
+        mock_repo.get_contents.side_effect = Exception("404 Not Found")
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        summary_file = str(tmp_path / "step-summary.md")
+        for k, v in {
+            "GH_TOKEN": "fake",
+            "REPO": "owner/repo",
+            "ALERT_NUMBER": "2",
+            "ALERT_PACKAGE": "idna",
+            "ALERT_ECOSYSTEM": "pip",
+            "ALERT_SEVERITY": "high",
+            "ALERT_PATCHED_VERSION": "3.15",
+            "DRY_RUN": "false",
+            "DISMISS_UNAFFECTED": "false",
+            "GITHUB_STEP_SUMMARY": summary_file,
+            "GITHUB_OUTPUT": output_file,
+        }.items():
+            monkeypatch.setenv(k, v)
+
+        with patch("scripts.post_alert_action.Github") as mock_gh:
+            mock_gh.return_value.get_repo.return_value = mock_repo
+            main()
+
+        outputs = open(output_file).read()
+        assert "action=dependabot_requested" in outputs
+        content = open(summary_file).read()
+        assert "Dependabot security update requested" in content


### PR DESCRIPTION
  Summary

  - When a pip transitive dependency (e.g. `idna` via `requests`) has no direct pin, detect the repo's lock tool (`uv/poetry/pipenv`) and run `uv lock --upgrade-package` (or equivalent) to create a bump PR. Previously the script gave up with `action=noop`.
  - Fix verdict extraction when `CLAUDE_VERBOSE=true`. The `--output-format json` wraps Claude's text in a JSON event array; the regex for `VERDICT_JSON` blocks never matched the escaped strings.
  - Fetch the patched version from the Dependabot alert API when `ALERT_PATCHED_VERSION` is empty (e.g. manual workflow dispatch).

  Changes

  - `scripts/post_alert_action.py` — `detect_pip_lock_tool()` checks for lock files via the GitHub API. `fetch_patched_version()` fills in missing patched version from the alert. Also searches `pyproject.toml` for direct pins.
  - `scripts/pip-lock-bump.sh` — New script mirroring `npm-bump.sh`: commits lock file changes via API and opens a PR.
  - `.github/workflows/investigate-security-alert.yml` — New `pip_lock_bump` steps between npm bump and private fork sections.
  - `scripts/extract_alert_verdict.py` — Parses JSON session logs to extract assistant text before searching for verdict blocks.
  - `scripts/alert_report.py` — Added `pip_lock_bump` action label.

  Test plan

  - [x] Run `investigate-security-alert` workflow on `debug-remediate` targeting `mozilla/blender` alert #2 (`idna`) — should produce [a bump PR updating uv.lock](https://github.com/mozilla/blender/pull/51)
    - [x] Confirm verbose mode (`CLAUDE_VERBOSE=true`) extracts the verdict
      - https://github.com/mozilla/blender/actions/runs/26532185016
  - [x] Verify `ruff check scripts/` and `pytest tests/` pass (CI covers this)
