### PR TITLE
fix: propagate old_version to deps for compatibility badge fallback

### DIFF
--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -230,11 +230,12 @@ def extract_metadata(pr: PullRequest) -> PRMetadata:
                 if not dep_by_name[name].version:
                     dep_by_name[name].version = new_ver
 
-    # Fill in missing update_type from version comparison
+    # Fill in missing old_version / update_type from commit title
     for dep in meta.dependencies:
-        old = dep.old_version or meta.old_version
-        if not dep.update_type and dep.version and old:
-            dep.update_type = compute_update_type(old, dep.version)
+        if not dep.old_version and meta.old_version:
+            dep.old_version = meta.old_version
+        if not dep.update_type and dep.version and dep.old_version:
+            dep.update_type = compute_update_type(dep.old_version, dep.version)
 
     # Derive new version and major-bump flag
     for dep in meta.dependencies:

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+
+def make_comment(body, login="mozilla-blender[bot]", created_at=None):
+    """Build a mock GitHub comment with .body, .user.login, and .created_at."""
+    c = MagicMock()
+    c.user.login = login
+    c.body = body
+    c.created_at = created_at
+    return c
+
+
+def make_review(login, state="APPROVED"):
+    """Build a mock PR review with .user.login and .state."""
+    r = MagicMock()
+    r.user.login = login
+    r.state = state
+    return r
+
+
+def make_commit(message, date=None):
+    """Build a mock commit with .commit.message and optional .commit.committer.date."""
+    c = MagicMock()
+    c.commit.message = message
+    if date is not None:
+        c.commit.committer.date = date
+    return c

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -13,10 +13,13 @@ from scripts.automerge_dependabot import (
     DependencyUpdate,
     MajorBumpPR,
     PRMetadata,
+    RetryPR,
     SkipPR,
     _normalize_pep440_range,
     _post_dependabot_recreate,
+    extract_metadata,
     gate_advisories,
+    gate_compatibility,
     gate_versions,
     main,
     version_in_range,
@@ -558,3 +561,101 @@ def test_process_pr_codeowner_approval_bypasses_major_gate():
         result = process_pr(config, gh, repo, pr)
 
     assert result is True
+
+
+# --- extract_metadata propagates old_version to deps ---
+
+
+def test_extract_metadata_propagates_old_version_to_single_dep():
+    """Single-dep PRs get old_version from commit title, not GROUP_VERSION_RE.
+
+    Regression: after a Dependabot force-push stripped the badge URL from
+    the PR body, gate_compatibility fell back to building badge URLs from
+    dep metadata. But dep.old_version was empty for single-dep PRs because
+    only GROUP_VERSION_RE populated it. meta.old_version (from the commit
+    title) was never copied to dep.old_version.
+    """
+    pr = MagicMock()
+    pr.head.ref = "dependabot/pip/ruff-0.15.13"
+
+    commit = MagicMock()
+    commit.commit.message = (
+        "Bump ruff from 0.15.12 to 0.15.13\n\n"
+        "---\n"
+        "updated-dependencies:\n"
+        "- dependency-name: ruff\n"
+        "  dependency-type: direct:development\n"
+        "  update-type: version-update:semver-patch\n"
+        "  dependency-version: 0.15.13\n"
+        "...\n"
+    )
+    commits = MagicMock()
+    commits.totalCount = 1
+    commits.__getitem__ = lambda self, i: commit
+    pr.get_commits.return_value = commits
+
+    meta = extract_metadata(pr)
+
+    assert meta.old_version == "0.15.12"
+    assert len(meta.dependencies) == 1
+    assert meta.dependencies[0].old_version == "0.15.12"
+
+
+# --- gate_compatibility fallback after force-push ---
+
+
+def test_gate_compatibility_builds_badge_url_when_body_has_no_badge():
+    """After a force-push strips the badge URL, the fallback path works.
+
+    gate_compatibility should build a badge URL from dep metadata
+    (including old_version propagated from meta) and fetch the SVG.
+    """
+    dep = DependencyUpdate(
+        name="ruff",
+        version="0.15.13",
+        dependency_type="direct:development",
+        update_type="version-update:semver-patch",
+        old_version="0.15.12",
+    )
+    meta = PRMetadata(
+        dependencies=[dep],
+        ecosystem="pip",
+        raw_ecosystem="pip",
+        old_version="0.15.12",
+        new_version="0.15.13",
+    )
+
+    pr = MagicMock()
+    pr.body = "Some PR body with no badge URL"
+
+    badge_svg = '<svg><text aria-label="compatibility: 89%">89%</text></svg>'
+    with patch(
+        "scripts.automerge_dependabot.fetch_badge_svg", return_value=badge_svg
+    ):
+        score = gate_compatibility(pr, meta, min_compat_score=70)
+
+    assert score == 89
+
+
+def test_gate_compatibility_raises_when_dep_has_no_old_version():
+    """Without old_version on deps and no badge in body, gate raises RetryPR."""
+    dep = DependencyUpdate(
+        name="ruff",
+        version="0.15.13",
+        dependency_type="direct:development",
+        update_type="version-update:semver-patch",
+        old_version="",  # missing
+    )
+    meta = PRMetadata(
+        dependencies=[dep],
+        ecosystem="pip",
+        raw_ecosystem="pip",
+        old_version="",
+        new_version="0.15.13",
+    )
+
+    pr = MagicMock()
+    pr.body = "No badge here"
+
+    with pytest.raises(RetryPR, match="no compatibility badge"):
+        gate_compatibility(pr, meta)

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -604,27 +604,28 @@ def test_extract_metadata_propagates_old_version_to_single_dep():
 # --- gate_compatibility fallback after force-push ---
 
 
-def test_gate_compatibility_builds_badge_url_when_body_has_no_badge():
-    """After a force-push strips the badge URL, the fallback path works.
-
-    gate_compatibility should build a badge URL from dep metadata
-    (including old_version propagated from meta) and fetch the SVG.
-    """
+def _ruff_bump_meta(old_version="0.15.12"):
+    """Build DependencyUpdate + PRMetadata for a ruff patch bump."""
     dep = DependencyUpdate(
         name="ruff",
         version="0.15.13",
         dependency_type="direct:development",
         update_type="version-update:semver-patch",
-        old_version="0.15.12",
+        old_version=old_version,
     )
     meta = PRMetadata(
         dependencies=[dep],
         ecosystem="pip",
         raw_ecosystem="pip",
-        old_version="0.15.12",
+        old_version=old_version,
         new_version="0.15.13",
     )
+    return dep, meta
 
+
+def test_gate_compatibility_builds_badge_url_when_body_has_no_badge():
+    """After a force-push strips the badge URL, the fallback path works."""
+    _, meta = _ruff_bump_meta()
     pr = MagicMock()
     pr.body = "Some PR body with no badge URL"
 
@@ -639,21 +640,7 @@ def test_gate_compatibility_builds_badge_url_when_body_has_no_badge():
 
 def test_gate_compatibility_raises_when_dep_has_no_old_version():
     """Without old_version on deps and no badge in body, gate raises RetryPR."""
-    dep = DependencyUpdate(
-        name="ruff",
-        version="0.15.13",
-        dependency_type="direct:development",
-        update_type="version-update:semver-patch",
-        old_version="",  # missing
-    )
-    meta = PRMetadata(
-        dependencies=[dep],
-        ecosystem="pip",
-        raw_ecosystem="pip",
-        old_version="",
-        new_version="0.15.13",
-    )
-
+    _, meta = _ruff_bump_meta(old_version="")
     pr = MagicMock()
     pr.body = "No badge here"
 

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.scripts import make_comment, make_review
+
 from scripts.automerge_dependabot import (
     AdvisorySkipPR,
     CIFailurePR,
@@ -365,13 +367,6 @@ def test_main_no_comment_when_review_major(monkeypatch):
 # --- has_blender_verdict ---
 
 
-def _gh_comment(body: str, login: str = "mozilla-blender[bot]"):
-    """Build a mock GitHub comment/review object with .body and .user.login."""
-    m = MagicMock()
-    m.body = body
-    m.user.login = login
-    return m
-
 
 @pytest.mark.parametrize(
     "verdict",
@@ -379,7 +374,7 @@ def _gh_comment(body: str, login: str = "mozilla-blender[bot]"):
 )
 def test_has_blender_verdict_from_comment(verdict):
     pr = MagicMock()
-    pr.get_issue_comments.return_value = [_gh_comment(body=verdict.comment("extra."))]
+    pr.get_issue_comments.return_value = [make_comment(body=verdict.comment("extra."))]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is True
 
@@ -388,7 +383,7 @@ def test_has_blender_verdict_from_review():
     pr = MagicMock()
     pr.get_issue_comments.return_value = []
     pr.get_reviews.return_value = [
-        _gh_comment(body=Verdict.APPROVED.comment("(high confidence)."))
+        make_comment(body=Verdict.APPROVED.comment("(high confidence)."))
     ]
     assert has_blender_verdict(pr) is True
 
@@ -396,7 +391,7 @@ def test_has_blender_verdict_from_review():
 def test_has_blender_verdict_false_when_no_verdict():
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _gh_comment(body="Reviewing this major version bump.")
+        make_comment(body="Reviewing this major version bump.")
     ]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is False
@@ -405,7 +400,7 @@ def test_has_blender_verdict_false_when_no_verdict():
 def test_has_blender_verdict_ignores_human_comments():
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _gh_comment(body=Verdict.SAFE.comment("to merge."), login="some-codeowner")
+        make_comment(body=Verdict.SAFE.comment("to merge."), login="some-codeowner")
     ]
     pr.get_reviews.return_value = []
     assert has_blender_verdict(pr) is False
@@ -420,7 +415,7 @@ def test_main_skips_dispatch_when_already_reviewed(monkeypatch, tmp_path):
         number=42,
         ref="dependabot/pip/ipware-7.0.0",
         comments=[
-            _gh_comment(body=Verdict.NO_VERDICT.comment("Manual review needed."))
+            make_comment(body=Verdict.NO_VERDICT.comment("Manual review needed."))
         ],
     )
     _run_main(
@@ -449,19 +444,13 @@ def test_main_no_comment_on_ci_failure(monkeypatch):
 
 def test_has_codeowner_approval_true():
     pr = MagicMock()
-    review = MagicMock()
-    review.state = "APPROVED"
-    review.user.login = "some-codeowner"
-    pr.get_reviews.return_value = [review]
+    pr.get_reviews.return_value = [make_review("some-codeowner")]
     assert has_codeowner_approval(pr) is True
 
 
 def test_has_codeowner_approval_returns_false_for_bots():
     pr = MagicMock()
-    review = MagicMock()
-    review.state = "APPROVED"
-    review.user.login = "some-app[bot]"
-    pr.get_reviews.return_value = [review]
+    pr.get_reviews.return_value = [make_review("some-app[bot]")]
     assert has_codeowner_approval(pr) is False
 
 
@@ -473,10 +462,7 @@ def test_has_codeowner_approval_false_no_reviews():
 
 def test_has_codeowner_approval_ignores_non_approval():
     pr = MagicMock()
-    review = MagicMock()
-    review.state = "COMMENTED"
-    review.user.login = "some-codeowner"
-    pr.get_reviews.return_value = [review]
+    pr.get_reviews.return_value = [make_review("some-codeowner", state="COMMENTED")]
     assert has_codeowner_approval(pr) is False
 
 
@@ -497,11 +483,9 @@ def test_process_pr_codeowner_approval_bypasses_major_gate():
     """Code-owner approval + BLEnder verdict = allow_major, no MajorBumpPR raised."""
     from scripts.automerge_dependabot import Config, process_pr
 
-    codeowner_review = MagicMock()
-    codeowner_review.state = "APPROVED"
-    codeowner_review.user.login = "some-codeowner"
+    codeowner_review = make_review("some-codeowner")
 
-    verdict_comment = _gh_comment(
+    verdict_comment = make_comment(
         body=Verdict.NEEDS_REVIEW.comment("Review needed.")
     )
 

--- a/tests/scripts/test_post_major_review.py
+++ b/tests/scripts/test_post_major_review.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from scripts.github_utils import Verdict
 from scripts.post_major_review import main
-from tests.scripts.test_automerge_dependabot import _gh_comment
+from tests.scripts import make_comment
 
 
 @patch("scripts.post_major_review.Github")
@@ -36,7 +36,7 @@ def test_no_duplicate_verdict_comment(mock_gh_cls, monkeypatch, tmp_path):
 
     pr = MagicMock()
     pr.get_issue_comments.return_value = [
-        _gh_comment(body=Verdict.NEEDS_REVIEW.comment())
+        make_comment(body=Verdict.NEEDS_REVIEW.comment())
     ]
     pr.get_reviews.return_value = []
     mock_gh_cls.return_value.get_repo.return_value.get_pull.return_value = pr

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, PropertyMock, patch
 
+from tests.scripts import make_comment, make_commit, make_review
+
 from scripts.sweep import check_alerts, process_repo
 
 # --- Shared timestamps ---
@@ -12,33 +14,6 @@ from scripts.sweep import check_alerts, process_repo
 T_EARLY = datetime(2025, 1, 1, tzinfo=timezone.utc)
 T_LATE = datetime(2025, 1, 2, tzinfo=timezone.utc)
 
-
-# --- Mock builders ---
-
-
-def _make_commit(message: str, date: datetime = T_EARLY):
-    """Build a mock commit object."""
-    c = MagicMock()
-    c.commit.message = message
-    c.commit.committer.date = date
-    return c
-
-
-def _make_comment(login: str, body: str, created_at: datetime = T_EARLY):
-    """Build a mock issue comment."""
-    c = MagicMock()
-    c.user.login = login
-    c.body = body
-    c.created_at = created_at
-    return c
-
-
-def _make_review(login: str, state: str = "APPROVED"):
-    """Build a mock PR review."""
-    r = MagicMock()
-    r.user.login = login
-    r.state = state
-    return r
 
 
 def _make_pr(
@@ -63,9 +38,9 @@ def _make_pr(
 
     commit_list = list(commits or [])
     if blender_commit:
-        commit_list.append(_make_commit("BLEnder fix(foo): update lockfile", T_LATE))
+        commit_list.append(make_commit("BLEnder fix(foo): update lockfile", T_LATE))
     if not commit_list:
-        commit_list.append(_make_commit("Bump foo from 1.0.0 to 2.0.0"))
+        commit_list.append(make_commit("Bump foo from 1.0.0 to 2.0.0"))
     pr.get_commits.return_value = commit_list
     pr.get_issue_comments.return_value = list(comments or [])
     pr.get_reviews.return_value = list(reviews or [])
@@ -114,9 +89,9 @@ class TestFixDispatch:
         pr, status = _make_pr(
             3,
             "failing",
-            commits=[_make_commit("Bump foo", T_EARLY)],
+            commits=[make_commit("Bump foo", T_EARLY)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_LATE)
+                make_comment("BLEnder picked up this PR.", "blender[bot]", T_LATE)
             ],
         )
         assert _run_sweep([(pr, status)]) == []
@@ -126,9 +101,9 @@ class TestFixDispatch:
         pr, status = _make_pr(
             4,
             "failing",
-            commits=[_make_commit("Bump foo", T_LATE)],
+            commits=[make_commit("Bump foo", T_LATE)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_EARLY)
+                make_comment("BLEnder picked up this PR.", "blender[bot]", T_EARLY)
             ],
         )
         actions = _run_sweep([(pr, status)])
@@ -140,11 +115,11 @@ class TestFixDispatch:
         pr, status = _make_pr(
             5,
             "failing",
-            commits=[_make_commit("Bump foo", T_EARLY)],
+            commits=[make_commit("Bump foo", T_EARLY)],
             comments=[
-                _make_comment(
-                    "blender[bot]",
+                make_comment(
                     "BLEnder could not fix this PR automatically.",
+                    "blender[bot]",
                     T_LATE,
                 )
             ],
@@ -156,11 +131,11 @@ class TestFixDispatch:
         pr, status = _make_pr(
             6,
             "failing",
-            commits=[_make_commit("Bump foo", T_LATE)],
+            commits=[make_commit("Bump foo", T_LATE)],
             comments=[
-                _make_comment(
-                    "blender[bot]",
+                make_comment(
                     "BLEnder could not fix this PR automatically.",
+                    "blender[bot]",
                     T_EARLY,
                 )
             ],
@@ -175,9 +150,9 @@ class TestFixDispatch:
             7,
             "failing",
             comments=[
-                _make_comment(
-                    "blender[bot]",
+                make_comment(
                     "BLEnder: will not auto-merge (CI has 1 failure(s)).",
+                    "blender[bot]",
                     T_LATE,
                 )
             ],
@@ -192,9 +167,9 @@ class TestFixDispatch:
             8,
             "failing",
             comments=[
-                _make_comment(
-                    "blender[bot]",
+                make_comment(
                     "BLEnder: skipped (score unknown). Will retry on next scheduled run.",
+                    "blender[bot]",
                     T_LATE,
                 )
             ],
@@ -209,9 +184,9 @@ class TestFixDispatch:
             9,
             "failing",
             blender_commit=True,
-            commits=[_make_commit("Bump foo", T_LATE)],
+            commits=[make_commit("Bump foo", T_LATE)],
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_EARLY)
+                make_comment("BLEnder picked up this PR.", "blender[bot]", T_EARLY)
             ],
         )
         assert _run_sweep([(pr, status)]) == []
@@ -233,7 +208,7 @@ class TestAutomergeDispatch:
             11,
             "passing",
             comments=[
-                _make_comment("blender[bot]", "BLEnder picked up this PR.", T_LATE)
+                make_comment("BLEnder picked up this PR.", "blender[bot]", T_LATE)
             ],
         )
         actions = _run_sweep([(pr, status)])
@@ -252,7 +227,7 @@ def _make_blender_bump_pr(number: int, ci_status: str, package: str = "foo"):
     pr.user.login = "mozilla-blender[bot]"
     pr.head.ref = f"blender/security-bump-{package}"
     type(pr.head).sha = PropertyMock(return_value="abc123")
-    pr.get_commits.return_value = [_make_commit(f"chore(deps): bump {package}")]
+    pr.get_commits.return_value = [make_commit(f"chore(deps): bump {package}")]
     pr.get_issue_comments.return_value = []
     return pr, ci_status
 
@@ -414,7 +389,7 @@ class TestCodeownerApprovalResetsFix:
             30,
             "failing",
             blender_commit=True,
-            reviews=[_make_review("some-codeowner")],
+            reviews=[make_review("some-codeowner")],
         )
         actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
@@ -425,15 +400,15 @@ class TestCodeownerApprovalResetsFix:
         pr, status = _make_pr(
             31,
             "failing",
-            commits=[_make_commit("Bump foo", T_EARLY)],
+            commits=[make_commit("Bump foo", T_EARLY)],
             comments=[
-                _make_comment(
-                    "blender[bot]",
+                make_comment(
                     "BLEnder could not fix this PR automatically.",
+                    "blender[bot]",
                     T_LATE,
                 )
             ],
-            reviews=[_make_review("some-codeowner")],
+            reviews=[make_review("some-codeowner")],
         )
         actions = _run_sweep([(pr, status)])
         assert len(actions) == 1
@@ -445,7 +420,7 @@ class TestCodeownerApprovalResetsFix:
             32,
             "failing",
             blender_commit=True,
-            reviews=[_make_review("some-app[bot]")],
+            reviews=[make_review("some-app[bot]")],
         )
         actions = _run_sweep([(pr, status)])
         assert actions == []


### PR DESCRIPTION
After a Dependabot force-push strips the badge URL from the PR body, `gate_compatibility` falls back to building badge URLs from dep metadata. Single-dep PRs never had `dep.old_version` set (only `GROUP_VERSION_RE` populated it for group PRs), so the fallback always failed with "no compatibility badge found in PR body".

Copy `meta.old_version` (parsed from the commit title) into any dep that lacks its own `old_version`.