### PR TITLE
fix(sweep): deduplicate security alert investigations with tags

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -121,14 +121,14 @@ jobs:
   remediate:
     needs: investigate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       action: ${{ steps.post-action.outputs.action }}
       fork_repo: ${{ steps.post-action.outputs.fork_repo }}
       advisory_ghsa_id: ${{ steps.post-action.outputs.advisory_ghsa_id }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-        with:
-          persist-credentials: false
 
       - name: Setup target repo
         id: setup
@@ -325,3 +325,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.setup.outputs.token }}
           REPO: ${{ steps.post-action.outputs.fork_repo }}
+
+      # Mark this alert as investigated so the sweep does not re-trigger it.
+      # Uses a lightweight tag on the blender repo.
+      - name: Tag alert as investigated
+        if: inputs.dry_run != 'true'
+        run: |
+          git tag "investigated/${TARGET_REPO}/${ALERT_NUMBER}"
+          git push origin "investigated/${TARGET_REPO}/${ALERT_NUMBER}"
+        env:
+          TARGET_REPO: ${{ inputs.target_repo }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -128,6 +128,8 @@ jobs:
       fork_repo: ${{ steps.post-action.outputs.fork_repo }}
       advisory_ghsa_id: ${{ steps.post-action.outputs.advisory_ghsa_id }}
     steps:
+      # persist-credentials left enabled so the "Tag alert as investigated"
+      # step can push a lightweight tag to the blender repo.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Setup target repo

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -128,9 +128,9 @@ jobs:
       fork_repo: ${{ steps.post-action.outputs.fork_repo }}
       advisory_ghsa_id: ${{ steps.post-action.outputs.advisory_ghsa_id }}
     steps:
-      # persist-credentials left enabled so the "Tag alert as investigated"
-      # step can push a lightweight tag to the blender repo.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
 
       - name: Setup target repo
         id: setup
@@ -333,8 +333,10 @@ jobs:
       - name: Tag alert as investigated
         if: inputs.dry_run != 'true'
         run: |
-          git tag "investigated/${TARGET_REPO}/${ALERT_NUMBER}"
-          git push origin "investigated/${TARGET_REPO}/${ALERT_NUMBER}"
+          TAG_NAME="investigated/${TARGET_REPO}/${ALERT_NUMBER}"
+          git tag "$TAG_NAME"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$TAG_NAME"
         env:
           TARGET_REPO: ${{ inputs.target_repo }}
           ALERT_NUMBER: ${{ inputs.alert_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 
@@ -43,6 +44,11 @@ BOT_LOGIN = "mozilla-blender[bot]"
 # Only process repos owned by these GitHub orgs/users.
 # Any installation from an owner not on this list is ignored.
 ALLOWED_OWNERS = frozenset({"mozilla", "mozilla-services", "mozilla-extensions"})
+
+# Used to skip alerts that already have an investigated tag.
+BLENDER_REPO = "mozilla/blender"
+INVESTIGATED_TAG_PREFIX = "investigated/"
+_INVESTIGATED_TAG_RE = re.compile(r"^investigated/(.+)/(\d+)$")
 
 
 @dataclass
@@ -125,7 +131,10 @@ def discover_repos(
     return results
 
 
-def process_repo(repo: Repository) -> list[Action]:
+def process_repo(
+    repo: Repository,
+    investigated: set[tuple[str, int]] | None = None,
+) -> list[Action]:
     """Check a single repo for actionable Dependabot PRs."""
     actions: list[Action] = []
 
@@ -221,7 +230,7 @@ def process_repo(repo: Repository) -> list[Action]:
 
     # Check Dependabot security alerts
     try:
-        alert_actions = check_alerts(repo)
+        alert_actions = check_alerts(repo, investigated=investigated)
         actions.extend(alert_actions)
     except Exception as e:
         print(f"    Error checking alerts: {e}")
@@ -229,7 +238,36 @@ def process_repo(repo: Repository) -> list[Action]:
     return actions
 
 
-def check_alerts(repo: Repository) -> list[Action]:
+def fetch_investigated_alerts(
+    integration: GithubIntegration,
+) -> set[tuple[str, int]]:
+    """Return (repo, alert_number) pairs already investigated.
+
+    Reads lightweight tags on the blender repo. Each successful
+    investigation creates a tag like ``investigated/{repo}/{number}``.
+    One API call fetches all tags.
+    """
+    investigated: set[tuple[str, int]] = set()
+
+    try:
+        install = integration.get_repo_installation("mozilla", "blender")
+        gh = integration.get_github_for_installation(install.id)
+        repo = gh.get_repo(BLENDER_REPO)
+        for tag in repo.get_tags():
+            m = _INVESTIGATED_TAG_RE.match(tag.name)
+            if m:
+                investigated.add((m.group(1), int(m.group(2))))
+    except Exception as e:
+        print(f"  Warning: could not fetch investigated tags: {e}")
+
+    print(f"  Found {len(investigated)} previously investigated alert(s)")
+    return investigated
+
+
+def check_alerts(
+    repo: Repository,
+    investigated: set[tuple[str, int]] | None = None,
+) -> list[Action]:
     """Check for open Dependabot security alerts and emit investigate actions.
 
     Uses PyGithub's raw requester because there is no built-in method
@@ -278,6 +316,11 @@ def check_alerts(repo: Repository) -> list[Action]:
             print(f"    Alert #{alert_number}: branch exists, skipping")
             continue
 
+        # Skip if a successful investigate run already completed for this alert
+        if investigated and (repo.full_name, alert_number) in investigated:
+            print(f"    Alert #{alert_number}: already investigated, skipping")
+            continue
+
         print(f"    Alert #{alert_number}: {package_name} ({severity})")
         actions.append(
             Action(
@@ -303,6 +346,9 @@ def sweep(app_id: str, private_key: str) -> list[Action]:
 
     actions: list[Action] = []
 
+    print("Checking previous investigate runs...")
+    investigated = fetch_investigated_alerts(integration)
+
     print("Discovering installations...")
     install_repos = discover_repos(integration)
 
@@ -316,7 +362,7 @@ def sweep(app_id: str, private_key: str) -> list[Action]:
                 continue
             print(f"\n  Checking {repo.full_name}...")
             try:
-                actions.extend(process_repo(repo))
+                actions.extend(process_repo(repo, investigated=investigated))
             except Exception as e:
                 print(f"    Error processing {repo.full_name}: {e}")
                 continue

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -25,3 +25,17 @@ def make_commit(message, date=None):
     if date is not None:
         c.commit.committer.date = date
     return c
+
+
+def make_branch(name):
+    """Build a mock branch object with .name."""
+    b = MagicMock()
+    b.name = name
+    return b
+
+
+def make_tag(name):
+    """Build a mock git tag object with .name."""
+    t = MagicMock()
+    t.name = name
+    return t

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from tests.scripts import make_comment, make_commit, make_review
+from tests.scripts import make_branch, make_comment, make_commit, make_review, make_tag
 
 from scripts.sweep import (
     ALLOWED_OWNERS,
@@ -324,13 +324,6 @@ def _make_alert(number: int, package: str, severity: str = "high"):
     }
 
 
-def _make_branch(name: str):
-    """Build a mock branch object."""
-    b = MagicMock()
-    b.name = name
-    return b
-
-
 class TestAlertDiscovery:
     def test_alert_discovery_emits_investigate_action(self):
         """Open alert with no existing branch -> investigate action."""
@@ -357,7 +350,7 @@ class TestAlertDiscovery:
             [_make_alert(42, "lodash")],
         )
         repo.get_branches.return_value = [
-            _make_branch("blender/security/42-lodash"),
+            make_branch("blender/security/42-lodash"),
         ]
 
         actions = check_alerts(repo)
@@ -382,7 +375,6 @@ class TestAlertDiscovery:
 
         actions = check_alerts(repo)
         assert actions == []
-
 
     def test_already_investigated_alert_skipped(self):
         """Alert with an investigated tag -> skip."""
@@ -417,20 +409,13 @@ class TestAlertDiscovery:
 # --- fetch_investigated_alerts ---
 
 
-def _make_tag(name: str):
-    """Build a mock git tag object."""
-    tag = MagicMock()
-    tag.name = name
-    return tag
-
-
 class TestFetchInvestigatedAlerts:
     def test_parses_investigated_tags(self):
         """Investigated tags are parsed into (repo, alert_number) pairs."""
         tags = [
-            _make_tag("investigated/mozilla/blurts-server/138"),
-            _make_tag("investigated/mozilla/fx-private-relay/161"),
-            _make_tag("v1.0.0"),  # unrelated tag, ignored
+            make_tag("investigated/mozilla/blurts-server/138"),
+            make_tag("investigated/mozilla/fx-private-relay/161"),
+            make_tag("v1.0.0"),  # unrelated tag, ignored
         ]
 
         integration = MagicMock()

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, PropertyMock, patch
 
+import pytest
+
 from tests.scripts import make_branch, make_comment, make_commit, make_review, make_tag
 
 from scripts.sweep import (
@@ -376,34 +378,27 @@ class TestAlertDiscovery:
         actions = check_alerts(repo)
         assert actions == []
 
-    def test_already_investigated_alert_skipped(self):
-        """Alert with an investigated tag -> skip."""
+    @pytest.mark.parametrize(
+        "alert_number, package, expected_count",
+        [
+            (138, "minimatch", 0),  # matches investigated set -> skip
+            (999, "new-vuln", 1),  # not in investigated set -> emit
+        ],
+        ids=["investigated-skipped", "uninvestigated-emitted"],
+    )
+    def test_investigated_alert_dedup(self, alert_number, package, expected_count):
+        """Alerts in the investigated set are skipped; others are emitted."""
         repo = MagicMock()
         repo.full_name = "mozilla/blurts-server"
         repo._requester.requestJsonAndCheck.return_value = (
             {},
-            [_make_alert(138, "minimatch")],
+            [_make_alert(alert_number, package)],
         )
         repo.get_branches.return_value = []
 
         investigated = {("mozilla/blurts-server", 138)}
         actions = check_alerts(repo, investigated=investigated)
-        assert actions == []
-
-    def test_uninvestigated_alert_emitted(self):
-        """Alert not in the investigated set -> emit action."""
-        repo = MagicMock()
-        repo.full_name = "mozilla/blurts-server"
-        repo._requester.requestJsonAndCheck.return_value = (
-            {},
-            [_make_alert(999, "new-vuln")],
-        )
-        repo.get_branches.return_value = []
-
-        investigated = {("mozilla/blurts-server", 138)}
-        actions = check_alerts(repo, investigated=investigated)
-        assert len(actions) == 1
-        assert actions[0].alert_number == 999
+        assert len(actions) == expected_count
 
 
 # --- fetch_investigated_alerts ---

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from tests.scripts import make_comment, make_commit, make_review
 
-from scripts.sweep import ALLOWED_OWNERS, check_alerts, process_repo, sweep
+from scripts.sweep import (
+    ALLOWED_OWNERS,
+    check_alerts,
+    fetch_investigated_alerts,
+    process_repo,
+    sweep,
+)
 
 # --- Shared timestamps ---
 
@@ -378,6 +384,76 @@ class TestAlertDiscovery:
         assert actions == []
 
 
+    def test_already_investigated_alert_skipped(self):
+        """Alert with an investigated tag -> skip."""
+        repo = MagicMock()
+        repo.full_name = "mozilla/blurts-server"
+        repo._requester.requestJsonAndCheck.return_value = (
+            {},
+            [_make_alert(138, "minimatch")],
+        )
+        repo.get_branches.return_value = []
+
+        investigated = {("mozilla/blurts-server", 138)}
+        actions = check_alerts(repo, investigated=investigated)
+        assert actions == []
+
+    def test_uninvestigated_alert_emitted(self):
+        """Alert not in the investigated set -> emit action."""
+        repo = MagicMock()
+        repo.full_name = "mozilla/blurts-server"
+        repo._requester.requestJsonAndCheck.return_value = (
+            {},
+            [_make_alert(999, "new-vuln")],
+        )
+        repo.get_branches.return_value = []
+
+        investigated = {("mozilla/blurts-server", 138)}
+        actions = check_alerts(repo, investigated=investigated)
+        assert len(actions) == 1
+        assert actions[0].alert_number == 999
+
+
+# --- fetch_investigated_alerts ---
+
+
+def _make_tag(name: str):
+    """Build a mock git tag object."""
+    tag = MagicMock()
+    tag.name = name
+    return tag
+
+
+class TestFetchInvestigatedAlerts:
+    def test_parses_investigated_tags(self):
+        """Investigated tags are parsed into (repo, alert_number) pairs."""
+        tags = [
+            _make_tag("investigated/mozilla/blurts-server/138"),
+            _make_tag("investigated/mozilla/fx-private-relay/161"),
+            _make_tag("v1.0.0"),  # unrelated tag, ignored
+        ]
+
+        integration = MagicMock()
+        install = MagicMock()
+        integration.get_repo_installation.return_value = install
+        gh = MagicMock()
+        integration.get_github_for_installation.return_value = gh
+        gh.get_repo.return_value.get_tags.return_value = tags
+
+        result = fetch_investigated_alerts(integration)
+        assert ("mozilla/blurts-server", 138) in result
+        assert ("mozilla/fx-private-relay", 161) in result
+        assert len(result) == 2
+
+    def test_api_failure_returns_empty_set(self):
+        """API error -> empty set, no crash."""
+        integration = MagicMock()
+        integration.get_repo_installation.side_effect = RuntimeError("oops")
+
+        result = fetch_investigated_alerts(integration)
+        assert result == set()
+
+
 # --- Code-owner approval resets fix guards ---
 
 
@@ -448,6 +524,7 @@ class TestOwnerAllowlist:
         with (
             patch("scripts.sweep.GithubIntegration", return_value=integration),
             patch("scripts.sweep.Auth.AppAuth"),
+            patch("scripts.sweep.fetch_investigated_alerts", return_value=set()),
             patch("scripts.sweep.process_repo") as mock_process,
         ):
             actions = sweep("12345", "fake-key")


### PR DESCRIPTION
The sweep re-triggered investigate workflows for alerts that had already been analyzed, burning compute every 30 minutes. Tag each completed investigation on the blender repo so the sweep can skip it on future runs.