### PR TITLE
fix: prevent repeated fix attempts on unfixable PRs

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -12,6 +12,7 @@ fix:
   dry_run: false
   max_claude_turns: 30
   max_budget_usd: 2.00
+  max_fix_attempts: 3
 
 investigate:
   enabled: true

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -390,6 +390,7 @@ def process_repo(
         print("    No .blender/blender.yml, skipping")
         return actions
 
+    repo_config = load_repo_config(repo)
     print("    Config found. Checking Dependabot PRs...")
     open_prs = list(repo.get_pulls(state="open"))
     dependabot_prs = [pr for pr in open_prs if pr.user.login == "dependabot[bot]"]
@@ -442,28 +443,59 @@ def process_repo(
                 print(f"    PR #{pr.number}: BLEnder already committed a fix, skipping")
                 continue
 
-            # Only skip if a bot fix-related comment was posted AFTER the
-            # latest commit.  Non-bot comments are ignored (login must
-            # end with "[bot]").  Stale comments (before a force-push) are
-            # also ignored so the fix can be retried on new code.
+            # "Could not fix" is a permanent block — once posted, the PR
+            # will not be retried unless a code owner approves.  Freshness
+            # no longer matters; Dependabot rebases don't clear this guard.
+            all_comments = list(pr.get_issue_comments())
+            could_not_fix = any(
+                c.user.login.endswith("[bot]")
+                and (c.body or "").startswith("BLEnder could not fix")
+                for c in all_comments
+            )
+            if could_not_fix and not codeowner_approved:
+                print(
+                    f"    PR #{pr.number}: BLEnder could not fix (permanent), skipping"
+                )
+                continue
+
+            # Hard cap: count total fix attempts (BLEnder fix commits +
+            # "could not fix" comments).  Prevents runaway LLM spend on
+            # PRs that keep failing.
+            fix_commit_count = sum(
+                1
+                for c in commits
+                if (c.commit.message or "").startswith("BLEnder fix(")
+            )
+            could_not_fix_count = sum(
+                1
+                for c in all_comments
+                if c.user.login.endswith("[bot]")
+                and (c.body or "").startswith("BLEnder could not fix")
+            )
+            total_fix_attempts = fix_commit_count + could_not_fix_count
+            max_attempts = repo_config.get("fix", {}).get("max_fix_attempts", 3)
+            if total_fix_attempts >= max_attempts:
+                print(
+                    f"    PR #{pr.number}: hit max fix attempts "
+                    f"({total_fix_attempts}/{max_attempts}), skipping"
+                )
+                continue
+
+            # Fresh "picked up" comment means a fix is already in progress.
             latest_commit_date = max(
                 (c.commit.committer.date for c in commits), default=None
             )
             if latest_commit_date is not None and not codeowner_approved:
-                fix_comments = [
-                    c
-                    for c in pr.get_issue_comments()
-                    if c.user.login.endswith("[bot]")
-                    and (
-                        (c.body or "").startswith("BLEnder picked up")
-                        or (c.body or "").startswith("BLEnder could not fix")
-                    )
-                ]
-                fresh_fix_comment = any(
-                    c.created_at >= latest_commit_date for c in fix_comments
+                picked_up = any(
+                    c.user.login.endswith("[bot]")
+                    and (c.body or "").startswith("BLEnder picked up")
+                    and c.created_at >= latest_commit_date
+                    for c in all_comments
                 )
-                if fresh_fix_comment:
-                    print(f"    PR #{pr.number}: fresh BLEnder fix comment, skipping")
+                if picked_up:
+                    print(
+                        f"    PR #{pr.number}: fresh BLEnder picked-up comment, skipping"
+                    )
                     continue
 
         print(f"    PR #{pr.number}: {result}")
@@ -485,10 +517,9 @@ def process_repo(
 
     # Check for auto-engineer work
     try:
-        config = load_repo_config(repo)
-        ae_actions = check_auto_engineer(repo, config)
+        ae_actions = check_auto_engineer(repo, repo_config)
         # Attach config settings that the workflow needs
-        ae_config = config.get("auto_engineer", {})
+        ae_config = repo_config.get("auto_engineer", {})
         for a in ae_actions:
             a.trusted_author_associations = ae_config.get(
                 "trusted_author_associations", "OWNER"

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -55,7 +55,15 @@ def _make_pr(
     return pr, ci_status
 
 
-def _run_sweep(prs: list[tuple[MagicMock, str]]) -> list:
+DEFAULT_CONFIG = {
+    "fix": {"max_fix_attempts": 3},
+    "auto_engineer": {},
+}
+
+
+def _run_sweep(
+    prs: list[tuple[MagicMock, str]], config: dict | None = None
+) -> list:
     """Build a mock repo, patch check_pr_status, and run process_repo."""
     repo = MagicMock()
     repo.full_name = "owner/repo"
@@ -72,7 +80,13 @@ def _run_sweep(prs: list[tuple[MagicMock, str]]) -> list:
             return "fix"
         return None
 
-    with patch("scripts.sweep.check_pr_status", side_effect=mock_check_pr_status):
+    with (
+        patch("scripts.sweep.check_pr_status", side_effect=mock_check_pr_status),
+        patch(
+            "scripts.sweep.load_repo_config",
+            return_value=config or DEFAULT_CONFIG,
+        ),
+    ):
         return process_repo(repo)
 
 
@@ -133,8 +147,8 @@ class TestFixDispatch:
         )
         assert _run_sweep([(pr, status)]) == []
 
-    def test_stale_could_not_fix_dispatches(self):
-        """Stale 'could not fix' comment -> dispatch fix."""
+    def test_stale_could_not_fix_still_blocks(self):
+        """Stale 'could not fix' comment -> still blocks (permanent guard)."""
         pr, status = _make_pr(
             6,
             "failing",
@@ -147,9 +161,7 @@ class TestFixDispatch:
                 )
             ],
         )
-        actions = _run_sweep([(pr, status)])
-        assert len(actions) == 1
-        assert actions[0].action == "fix"
+        assert _run_sweep([(pr, status)]) == []
 
     def test_automerge_comment_does_not_block_fix(self):
         """'will not auto-merge' comment only -> dispatch fix."""
@@ -197,6 +209,70 @@ class TestFixDispatch:
             ],
         )
         assert _run_sweep([(pr, status)]) == []
+
+
+# --- Hard cap on fix attempts ---
+
+
+def _could_not_fix_comments(n: int) -> list:
+    """Build *n* 'could not fix' bot comments, alternating timestamps."""
+    timestamps = [T_EARLY, T_LATE]
+    return [
+        make_comment(
+            "BLEnder could not fix this PR automatically.",
+            "blender[bot]",
+            timestamps[i % len(timestamps)],
+        )
+        for i in range(n)
+    ]
+
+
+class TestFixAttemptCap:
+    def test_under_cap_dispatches(self):
+        """One 'could not fix' comment with max=3 -> still dispatches."""
+        pr, status = _make_pr(
+            40,
+            "failing",
+            comments=_could_not_fix_comments(1),
+        )
+        # One could-not-fix comment blocks due to permanent guard,
+        # but code-owner approval overrides it.  With cap=3 and only
+        # 1 attempt, the cap itself does not block.
+        pr.get_reviews.return_value = [make_review("some-codeowner")]
+        actions = _run_sweep([(pr, status)])
+        assert len(actions) == 1
+
+    def test_at_cap_blocks(self):
+        """Three 'could not fix' comments with max=3 -> blocked even with approval."""
+        pr, status = _make_pr(
+            41,
+            "failing",
+            comments=_could_not_fix_comments(3),
+            reviews=[make_review("some-codeowner")],
+        )
+        assert _run_sweep([(pr, status)]) == []
+
+    def test_fix_commits_count_toward_cap(self):
+        """BLEnder fix commit + 2 'could not fix' comments = 3 attempts -> blocked."""
+        pr, status = _make_pr(
+            42,
+            "failing",
+            blender_commit=True,
+            comments=_could_not_fix_comments(2),
+            reviews=[make_review("some-codeowner")],
+        )
+        assert _run_sweep([(pr, status)]) == []
+
+    def test_custom_cap_from_config(self):
+        """Repo can set a custom max_fix_attempts."""
+        pr, status = _make_pr(
+            43,
+            "failing",
+            comments=_could_not_fix_comments(1),
+            reviews=[make_review("some-codeowner")],
+        )
+        config = {"fix": {"max_fix_attempts": 1}, "auto_engineer": {}}
+        assert _run_sweep([(pr, status)], config=config) == []
 
 
 # --- CI-passing PRs (result == "automerge") ---
@@ -450,8 +526,8 @@ class TestCodeownerApprovalResetsFix:
         assert len(actions) == 1
         assert actions[0].action == "fix"
 
-    def test_codeowner_approval_overrides_fresh_fix_comment(self):
-        """Code owner approved + fresh 'could not fix' comment -> dispatch fix."""
+    def test_codeowner_approval_overrides_could_not_fix(self):
+        """Code owner approved + 'could not fix' comment -> dispatch fix."""
         pr, status = _make_pr(
             31,
             "failing",


### PR DESCRIPTION
Make "could not fix" comments a permanent block — Dependabot rebases no longer clear the guard. Add a hard cap (default 3) on total fix attempts per PR, counting both fix commits and "could not fix" comments. Code-owner approval overrides the permanent block but not the cap. Configurable via fix.max_fix_attempts in blender.yml.