### PR TITLE
fix: filter lock file diffs from review prompt, remove network sandbox

### DIFF
--- a/claude-settings.json
+++ b/claude-settings.json
@@ -2,10 +2,7 @@
   "sandbox": {
     "enabled": true,
     "failIfUnavailable": true,
-    "autoAllowBashIfSandboxed": true,
-    "network": {
-      "allowedDomains": []
-    }
+    "autoAllowBashIfSandboxed": true
   },
   "allowUnsandboxedCommands": false
 }

--- a/scripts/gather_context.py
+++ b/scripts/gather_context.py
@@ -36,6 +36,54 @@ except ImportError:
     from sanitize import sanitize_for_prompt  # type: ignore[no-redef]
 
 
+# -- Lock file filtering ------------------------------------------------------
+
+LOCK_FILES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Pipfile.lock",
+    "poetry.lock",
+    "uv.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "Cargo.lock",
+    "go.sum",
+}
+
+
+def filter_lock_file_diff(diff: str) -> str:
+    """Remove lock file hunks from a unified diff.
+
+    Splits on ``diff --git`` boundaries, drops sections whose path
+    matches a known lock file, and inserts a placeholder.
+    """
+    if not diff:
+        return diff
+
+    # Split on file boundaries, keeping the delimiter
+    parts = re.split(r"(?=^diff --git )", diff, flags=re.MULTILINE)
+
+    filtered: list[str] = []
+    omitted = False
+    for part in parts:
+        if not part.strip():
+            continue
+        # Extract the b/ path from "diff --git a/... b/..."
+        m = re.match(r"diff --git a/.+ b/(.+)", part)
+        if m:
+            filename = m.group(1).split("/")[-1]
+            if filename in LOCK_FILES:
+                omitted = True
+                continue
+        filtered.append(part)
+
+    result = "".join(filtered)
+    if omitted:
+        result += "\n[lock file changes omitted]\n"
+    return result
+
+
 # -- GitHub API helpers -------------------------------------------------------
 
 MAX_LINES_PER_STEP = 200
@@ -341,6 +389,7 @@ def main() -> None:
     # Fetch PR diff
     print("Fetching PR diff...")
     pr_diff = fetch_pr_diff(repo, pr_number)
+    pr_diff_filtered = filter_lock_file_diff(pr_diff)
 
     # Fetch release notes
     print("Fetching release notes...")
@@ -379,7 +428,7 @@ def main() -> None:
     safe_title = sanitize_for_prompt(pr["title"])
     safe_checks = sanitize_for_prompt(failing_checks)
     safe_logs = sanitize_for_prompt(ci_logs)
-    safe_diff = sanitize_for_prompt(pr_diff)
+    safe_diff = sanitize_for_prompt(pr_diff_filtered)
     safe_body = sanitize_for_prompt(pr["body"])
     safe_notes = sanitize_for_prompt(release_notes)
     safe_ci = sanitize_for_prompt(ci_status)

--- a/tests/scripts/test_gather_context.py
+++ b/tests/scripts/test_gather_context.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from scripts.gather_context import build_prompt, fetch_ci_logs, parse_job_log
+from scripts.gather_context import (
+    build_prompt,
+    fetch_ci_logs,
+    filter_lock_file_diff,
+    parse_job_log,
+)
 from scripts.sanitize import sanitize_for_prompt
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
@@ -265,3 +270,86 @@ def test_fetch_ci_logs_circleci_warning(mock_gh_api):
     assert has_circleci
     assert "CircleCI" in logs
     assert "cannot fetch" in logs
+
+
+# -- filter_lock_file_diff tests ----------------------------------------------
+
+DIFF_WITH_LOCK_FILES = """\
+diff --git a/src/index.ts b/src/index.ts
+index abc1234..def5678 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,3 +1,4 @@
+ import foo from 'foo';
++import bar from 'bar';
+ console.log(foo);
+diff --git a/package-lock.json b/package-lock.json
+index 1111111..2222222 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -1,5000 +1,6000 @@
+ { "lots": "of json" }
+diff --git a/yarn.lock b/yarn.lock
+index 3333333..4444444 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1,100 +1,200 @@
+ dependency tree here
+diff --git a/tsconfig.json b/tsconfig.json
+index 5555555..6666666 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -1,3 +1,4 @@
+ { "strict": true }
+"""
+
+
+def test_filter_lock_file_diff_removes_lock_files():
+    result = filter_lock_file_diff(DIFF_WITH_LOCK_FILES)
+    assert "package-lock.json" not in result
+    assert "yarn.lock" not in result
+
+
+def test_filter_lock_file_diff_preserves_other_files():
+    result = filter_lock_file_diff(DIFF_WITH_LOCK_FILES)
+    assert "src/index.ts" in result
+    assert "tsconfig.json" in result
+    assert "import bar from 'bar'" in result
+
+
+def test_filter_lock_file_diff_inserts_placeholder():
+    result = filter_lock_file_diff(DIFF_WITH_LOCK_FILES)
+    assert "[lock file changes omitted]" in result
+
+
+def test_filter_lock_file_diff_no_lock_files():
+    diff = """\
+diff --git a/src/index.ts b/src/index.ts
+index abc1234..def5678 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,3 +1,4 @@
+ import foo from 'foo';
+"""
+    result = filter_lock_file_diff(diff)
+    assert "[lock file changes omitted]" not in result
+    assert "src/index.ts" in result
+
+
+def test_filter_lock_file_diff_nested_lock_file():
+    """Lock files in subdirectories should also be filtered."""
+    diff = """\
+diff --git a/frontend/package-lock.json b/frontend/package-lock.json
+index 1111111..2222222 100644
+--- a/frontend/package-lock.json
++++ b/frontend/package-lock.json
+@@ -1,100 +1,200 @@
+ lots of json
+"""
+    result = filter_lock_file_diff(diff)
+    assert "package-lock.json" not in result
+    assert "[lock file changes omitted]" in result
+
+
+def test_filter_lock_file_diff_empty_input():
+    assert filter_lock_file_diff("") == ""


### PR DESCRIPTION
Lock file diffs (package-lock.json, yarn.lock, etc.) bloated the major review prompt. The TypeScript 6.0.3 PR consumed ~$0.55 of the $1 budget on cache-creation tokens alone, leaving no room for analysis.

Strip lock file hunks from the unified diff before prompt assembly. Ten lock file names covered across all ecosystems.

Remove the network sandbox config that triggered bwrap's --unshare-net flag. Some runners lack the kernel capability for network namespaces. Filesystem sandboxing and run-claude.sh token controls remain.