### PR TITLE
Allow taskcluster and petemoore owners in sweep

### DIFF
--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -45,7 +45,10 @@ BOT_LOGIN = "mozilla-blender[bot]"
 
 # Only process repos owned by these GitHub orgs/users.
 # Any installation from an owner not on this list is ignored.
-ALLOWED_OWNERS = frozenset({"mozilla", "mozilla-services", "mozilla-extensions"})
+# petemoore is a personal staging fork used to validate taskcluster onboarding.
+ALLOWED_OWNERS = frozenset(
+    {"mozilla", "mozilla-services", "mozilla-extensions", "taskcluster", "petemoore"}
+)
 
 # Used to skip alerts that already have an investigated tag.
 BLENDER_REPO = "mozilla/blender"

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -564,6 +564,8 @@ class TestOwnerAllowlist:
     def test_allowed_owner_is_processed(self):
         """Repo under an allowed owner -> process it."""
         assert "mozilla" in ALLOWED_OWNERS
+        assert "taskcluster" in ALLOWED_OWNERS
+        assert "petemoore" in ALLOWED_OWNERS
 
     def test_disallowed_owner_is_skipped(self):
         """Repo under an unknown owner -> skipped, no process_repo call."""


### PR DESCRIPTION
Adds `taskcluster` and `petemoore` to `ALLOWED_OWNERS` in `scripts/sweep.py` so the scheduled sweep processes their repos:

- **`taskcluster`** — to onboard the `taskcluster/taskcluster` monorepo.
- **`petemoore`** — a personal fork of taskcluster, used as a staging environment to validate the `.blender/` config before going live on the real repo.

Discussed with the maintainer beforehand.

Follow-ups (not in this PR): install the BLEnder App on `taskcluster/taskcluster` and `petemoore/taskcluster`, and add a `.blender/` config to each.

Local checks pass: `ruff check scripts/`, `ruff format --check scripts/`, `pytest tests/scripts/test_sweep.py` (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)