### PR TITLE
feat: open a PR on the private fork and stop leaking alerts publicly

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -328,14 +328,16 @@ jobs:
           BLENDER_MODE: fix
           CLAUDE_VERBOSE: ${{ inputs.verbose }}
 
-      - name: Commit and push fix
+      - name: Commit fix and open fork PR
         id: commit
         if: steps.post-action.outputs.action == 'private_fork' && inputs.dry_run != 'true'
         working-directory: fork
-        run: ${{ github.workspace }}/scripts/commit.sh
+        run: ${{ github.workspace }}/scripts/fork-fix-pr.sh
         env:
           GH_TOKEN: ${{ steps.setup.outputs.token }}
           REPO: ${{ steps.post-action.outputs.fork_repo }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+          ALERT_PACKAGE: ${{ inputs.alert_package }}
 
       # Mark this alert as investigated so the sweep does not re-trigger it.
       # Uses a lightweight tag on the blender repo.

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -12,21 +12,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pr-lib.sh
+source "${SCRIPT_DIR}/pr-lib.sh"
 
-if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
-  echo "Error: GH_TOKEN and REPO are required."
-  exit 1
-fi
+require_token_repo
 
 # Read commit message from Claude, fall back to default
-if [ -f .blender-commit-msg ]; then
-  COMMIT_MSG=$(cat .blender-commit-msg)
-  rm .blender-commit-msg
-else
-  COMMIT_MSG="BLEnder fix: auto-fix CI failure from dependency update"
-fi
+COMMIT_MSG=$(read_commit_msg "BLEnder fix: auto-fix CI failure from dependency update")
 
-if git diff --quiet && git diff --cached --quiet; then
+if no_changes; then
   echo "No changes to commit."
   echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
   exit 0
@@ -39,7 +33,7 @@ CHANGED_FILES=()
 while IFS= read -r file; do
   [ -z "$file" ] && continue
   CHANGED_FILES+=("$file")
-done < <(git diff --name-only)
+done < <(list_changed_files)
 
 COMMIT=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 

--- a/scripts/extract_alert_verdict.py
+++ b/scripts/extract_alert_verdict.py
@@ -15,24 +15,49 @@ import sys
 VERDICT_FILE = ".blender-alert-verdict.json"
 
 
-def _extract_text_from_json_log(log: str) -> str:
-    """Extract assistant text from --output-format json session logs."""
+def _iter_json_docs(log: str):
+    """Yield parsed JSON documents from a Claude session log.
+
+    Handles a single array (--output-format json), JSON-lines (a
+    --verbose stream), and logs where non-JSON stderr noise is mixed in
+    (e.g. a trust warning that `2>&1` merges into the file).
+    """
+    stripped = log.strip()
+    if not stripped:
+        return
+    # Fast path: the whole log is one JSON document.
     try:
-        events = json.loads(log)
-    except (json.JSONDecodeError, TypeError):
-        return ""
-
-    if not isinstance(events, list):
-        return ""
-
-    parts = []
-    for event in events:
-        msg = event.get("message") if isinstance(event, dict) else None
-        if not msg or msg.get("role") != "assistant":
+        yield json.loads(stripped)
+        return
+    except json.JSONDecodeError:
+        pass
+    # Fallback: parse each line that looks like JSON, skipping noise.
+    for line in stripped.splitlines():
+        line = line.strip()
+        if not line or line[0] not in "[{":
             continue
-        for block in msg.get("content", []):
-            if isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block["text"])
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def _extract_text_from_json_log(log: str) -> str:
+    """Extract assistant and result text from Claude session logs."""
+    parts = []
+    for doc in _iter_json_docs(log):
+        events = doc if isinstance(doc, list) else [doc]
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            # The final result event carries the last message text.
+            if event.get("type") == "result" and isinstance(event.get("result"), str):
+                parts.append(event["result"])
+            msg = event.get("message")
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                for block in msg.get("content", []):
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        parts.append(block["text"])
     return "\n".join(parts)
 
 

--- a/scripts/fork-fix-pr.sh
+++ b/scripts/fork-fix-pr.sh
@@ -17,30 +17,24 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pr-lib.sh
+source "${SCRIPT_DIR}/pr-lib.sh"
 
-if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
-  echo "Error: GH_TOKEN and REPO are required."
-  exit 1
-fi
+require_token_repo
 
 if [ -z "${ALERT_NUMBER:-}" ] || [ -z "${ALERT_PACKAGE:-}" ]; then
   echo "Error: ALERT_NUMBER and ALERT_PACKAGE are required."
   exit 1
 fi
 
-if git diff --quiet && git diff --cached --quiet; then
+if no_changes; then
   echo "No changes to commit. Nothing to do."
   echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
   exit 0
 fi
 
 # Read commit message from Claude, fall back to default
-if [ -f .blender-commit-msg ]; then
-  COMMIT_MSG=$(cat .blender-commit-msg)
-  rm .blender-commit-msg
-else
-  COMMIT_MSG="BLEnder fix: security update for ${ALERT_PACKAGE}"
-fi
+COMMIT_MSG=$(read_commit_msg "BLEnder fix: security update for ${ALERT_PACKAGE}")
 
 BRANCH_NAME="blender/fix-alert-${ALERT_NUMBER}"
 
@@ -52,25 +46,16 @@ CHANGED_FILES=()
 while IFS= read -r file; do
   [ -z "$file" ] && continue
   CHANGED_FILES+=("$file")
-done < <(git diff --name-only)
+done < <(list_changed_files)
 
 COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
-# Create branch ref, updating it if it already exists
-gh api "repos/${REPO}/git/refs" \
-  --method POST \
-  --field "ref=refs/heads/${BRANCH_NAME}" \
-  --field "sha=${COMMIT_SHA}" || {
-    echo "Branch ${BRANCH_NAME} already exists. Updating."
-    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
-      --method PATCH \
-      --field "sha=${COMMIT_SHA}"
-  }
+create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
 
 echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
 
 # Skip PR creation if one is already open for this branch
-EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
 if [ -n "$EXISTING_PR" ]; then
   echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
   echo "pushed=true" >> "${GITHUB_OUTPUT:-/dev/null}"
@@ -78,14 +63,7 @@ if [ -n "$EXISTING_PR" ]; then
 fi
 
 # Build PR body. The fork is private, so include the verdict context.
-SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
-REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
-RUN_ID="${GITHUB_RUN_ID:-}"
-if [ -n "$RUN_ID" ]; then
-  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
-else
-  RUN_LINK="BLEnder investigation"
-fi
+RUN_LINK=$(run_link)
 
 VERDICT_SECTION=""
 if [ -f .blender-alert-verdict.json ]; then

--- a/scripts/fork-fix-pr.sh
+++ b/scripts/fork-fix-pr.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# BLEnder fork fix PR: commit Claude's fix to a branch on the private
+# advisory fork and open a pull request there.
+#
+# Runs in the private fork checkout after Claude's fix process exits.
+# The fork is private to advisory collaborators, so the PR and its body
+# carry no public disclosure risk. Reads the commit message from
+# .blender-commit-msg and delegates blob -> tree -> commit to
+# git-commit-api.sh.
+#
+# Environment variables:
+#   GH_TOKEN       -- GitHub token with contents+pull-requests write (required)
+#   REPO           -- private fork repo, e.g. org/ghsa-xxxx-yyyy-zzzz (required)
+#   ALERT_NUMBER   -- Dependabot alert number (required)
+#   ALERT_PACKAGE  -- package name (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "Error: GH_TOKEN and REPO are required."
+  exit 1
+fi
+
+if [ -z "${ALERT_NUMBER:-}" ] || [ -z "${ALERT_PACKAGE:-}" ]; then
+  echo "Error: ALERT_NUMBER and ALERT_PACKAGE are required."
+  exit 1
+fi
+
+if git diff --quiet && git diff --cached --quiet; then
+  echo "No changes to commit. Nothing to do."
+  echo "pushed=false" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+# Read commit message from Claude, fall back to default
+if [ -f .blender-commit-msg ]; then
+  COMMIT_MSG=$(cat .blender-commit-msg)
+  rm .blender-commit-msg
+else
+  COMMIT_MSG="BLEnder fix: security update for ${ALERT_PACKAGE}"
+fi
+
+BRANCH_NAME="blender/fix-alert-${ALERT_NUMBER}"
+
+DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
+PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+
+# Collect changed files explicitly so we control what gets committed
+CHANGED_FILES=()
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  CHANGED_FILES+=("$file")
+done < <(git diff --name-only)
+
+COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
+
+# Create branch ref, updating it if it already exists
+gh api "repos/${REPO}/git/refs" \
+  --method POST \
+  --field "ref=refs/heads/${BRANCH_NAME}" \
+  --field "sha=${COMMIT_SHA}" || {
+    echo "Branch ${BRANCH_NAME} already exists. Updating."
+    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
+      --method PATCH \
+      --field "sha=${COMMIT_SHA}"
+  }
+
+echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
+
+# Skip PR creation if one is already open for this branch
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
+  echo "pushed=true" >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
+# Build PR body. The fork is private, so include the verdict context.
+SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+if [ -n "$RUN_ID" ]; then
+  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
+else
+  RUN_LINK="BLEnder investigation"
+fi
+
+VERDICT_SECTION=""
+if [ -f .blender-alert-verdict.json ]; then
+  REASON=$(jq -r '.reason // ""' .blender-alert-verdict.json)
+  PATHS=$(jq -r '(.vulnerable_paths // []) | map("- `" + . + "`") | join("\n")' .blender-alert-verdict.json)
+  VERDICT_SECTION="
+
+## Investigation verdict
+
+${REASON}"
+  if [ -n "$PATHS" ]; then
+    VERDICT_SECTION="${VERDICT_SECTION}
+
+### Vulnerable paths
+
+${PATHS}"
+  fi
+fi
+
+PR_BODY="## Summary
+
+Security fix for **${ALERT_PACKAGE}** (Dependabot alert #${ALERT_NUMBER}).
+Prepared on the private advisory fork for review before publication.${VERDICT_SECTION}
+
+---
+*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
+
+PR_TITLE="Security fix: ${ALERT_PACKAGE} (alert #${ALERT_NUMBER})"
+
+gh pr create \
+  --repo "$REPO" \
+  --head "$BRANCH_NAME" \
+  --base "$DEFAULT_BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY"
+
+echo "PR created."
+echo "pushed=true" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/scripts/npm-bump.sh
+++ b/scripts/npm-bump.sh
@@ -15,11 +15,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pr-lib.sh
+source "${SCRIPT_DIR}/pr-lib.sh"
 
-if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
-  echo "Error: GH_TOKEN and REPO are required."
-  exit 1
-fi
+require_token_repo
 
 if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
   echo "Error: PACKAGE and ALERT_NUMBER are required."
@@ -35,7 +34,7 @@ fi
 BRANCH_NAME="blender/security-bump-${PACKAGE}"
 
 # Check for existing open PR on this branch — exit before any API calls
-EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
 if [ -n "$EXISTING_PR" ]; then
   echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
   exit 0
@@ -60,36 +59,13 @@ done
 COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
 # Create branch ref
-gh api "repos/${REPO}/git/refs" \
-  --method POST \
-  --field "ref=refs/heads/${BRANCH_NAME}" \
-  --field "sha=${COMMIT_SHA}" || {
-    echo "Branch ${BRANCH_NAME} already exists. Updating."
-    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
-      --method PATCH \
-      --field "sha=${COMMIT_SHA}"
-  }
+create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
 
 echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
 
 # Build PR body
-SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
-REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
-RUN_ID="${GITHUB_RUN_ID:-}"
-if [ -n "$RUN_ID" ]; then
-  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
-else
-  RUN_LINK="BLEnder investigation"
-fi
-
-# On a public repo, linking the Dependabot alert discloses the package,
-# CVE, and severity. Keep the detail only for private/internal repos.
-VISIBILITY=$(gh api "repos/${REPO}" --jq '.visibility')
-if [ "$VISIBILITY" = "public" ]; then
-  ALERT_LINE="Resolves a flagged transitive dependency advisory."
-else
-  ALERT_LINE="Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER})."
-fi
+RUN_LINK=$(run_link)
+ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
 
 PR_BODY="## Summary
 

--- a/scripts/npm-bump.sh
+++ b/scripts/npm-bump.sh
@@ -82,9 +82,18 @@ else
   RUN_LINK="BLEnder investigation"
 fi
 
+# On a public repo, linking the Dependabot alert discloses the package,
+# CVE, and severity. Keep the detail only for private/internal repos.
+VISIBILITY=$(gh api "repos/${REPO}" --jq '.visibility')
+if [ "$VISIBILITY" = "public" ]; then
+  ALERT_LINE="Resolves a flagged transitive dependency advisory."
+else
+  ALERT_LINE="Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER})."
+fi
+
 PR_BODY="## Summary
 
-Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER}).
+${ALERT_LINE}
 
 This is a transitive dependency update. Only \`package-lock.json\` (and possibly \`package.json\`) changed.
 

--- a/scripts/pip-lock-bump.sh
+++ b/scripts/pip-lock-bump.sh
@@ -99,9 +99,18 @@ else
   RUN_LINK="BLEnder investigation"
 fi
 
+# On a public repo, linking the Dependabot alert discloses the package,
+# CVE, and severity. Keep the detail only for private/internal repos.
+VISIBILITY=$(gh api "repos/${REPO}" --jq '.visibility')
+if [ "$VISIBILITY" = "public" ]; then
+  ALERT_LINE="Resolves a flagged transitive dependency advisory."
+else
+  ALERT_LINE="Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER})."
+fi
+
 PR_BODY="## Summary
 
-Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER}).
+${ALERT_LINE}
 
 This is a transitive dependency update via \`${PIP_LOCK_TOOL}\`. Only lock files changed.
 

--- a/scripts/pip-lock-bump.sh
+++ b/scripts/pip-lock-bump.sh
@@ -17,11 +17,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pr-lib.sh
+source "${SCRIPT_DIR}/pr-lib.sh"
 
-if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
-  echo "Error: GH_TOKEN and REPO are required."
-  exit 1
-fi
+require_token_repo
 
 if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
   echo "Error: PACKAGE and ALERT_NUMBER are required."
@@ -60,7 +59,7 @@ fi
 BRANCH_NAME="blender/security-bump-${PACKAGE}"
 
 # Check for existing open PR on this branch
-EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
+EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
 if [ -n "$EXISTING_PR" ]; then
   echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
   exit 0
@@ -77,36 +76,13 @@ PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sh
 COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
 # Create branch ref
-gh api "repos/${REPO}/git/refs" \
-  --method POST \
-  --field "ref=refs/heads/${BRANCH_NAME}" \
-  --field "sha=${COMMIT_SHA}" || {
-    echo "Branch ${BRANCH_NAME} already exists. Updating."
-    gh api "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" \
-      --method PATCH \
-      --field "sha=${COMMIT_SHA}"
-  }
+create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
 
 echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
 
 # Build PR body
-SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
-REPOSITORY="${GITHUB_REPOSITORY:-mozilla/blender}"
-RUN_ID="${GITHUB_RUN_ID:-}"
-if [ -n "$RUN_ID" ]; then
-  RUN_LINK="[BLEnder investigation](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
-else
-  RUN_LINK="BLEnder investigation"
-fi
-
-# On a public repo, linking the Dependabot alert discloses the package,
-# CVE, and severity. Keep the detail only for private/internal repos.
-VISIBILITY=$(gh api "repos/${REPO}" --jq '.visibility')
-if [ "$VISIBILITY" = "public" ]; then
-  ALERT_LINE="Resolves a flagged transitive dependency advisory."
-else
-  ALERT_LINE="Bumps **${PACKAGE}** to \`${PATCHED_VERSION:-latest}\` to resolve [Dependabot alert #${ALERT_NUMBER}](https://github.com/${REPO}/security/dependabot/${ALERT_NUMBER})."
-fi
+RUN_LINK=$(run_link)
+ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
 
 PR_BODY="## Summary
 

--- a/scripts/pr-lib.sh
+++ b/scripts/pr-lib.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Shared helpers for scripts that create commits, branches, and PRs via
+# the GitHub API. Source this file; do not execute it.
+
+# Require GH_TOKEN and REPO to be set, else exit 1.
+require_token_repo() {
+  if [ -z "${GH_TOKEN:-}" ] || [ -z "${REPO:-}" ]; then
+    echo "Error: GH_TOKEN and REPO are required."
+    exit 1
+  fi
+}
+
+# Echo the commit message from .blender-commit-msg (removing the file
+# afterward), or the provided default. Usage: read_commit_msg "default"
+read_commit_msg() {
+  if [ -f .blender-commit-msg ]; then
+    cat .blender-commit-msg
+    rm .blender-commit-msg
+  else
+    echo "$1"
+  fi
+}
+
+# Return 0 when there are no staged or unstaged changes.
+no_changes() {
+  git diff --quiet && git diff --cached --quiet
+}
+
+# Echo the list of changed (unstaged) files, one per line.
+list_changed_files() {
+  git diff --name-only
+}
+
+# Echo a markdown link to the current Actions run, or a plain label.
+run_link() {
+  local server="${GITHUB_SERVER_URL:-https://github.com}"
+  local repository="${GITHUB_REPOSITORY:-mozilla/blender}"
+  local run_id="${GITHUB_RUN_ID:-}"
+  if [ -n "$run_id" ]; then
+    echo "[BLEnder investigation](${server}/${repository}/actions/runs/${run_id})"
+  else
+    echo "BLEnder investigation"
+  fi
+}
+
+# Create a branch ref at SHA, updating it if it already exists.
+# Usage: create_or_update_branch REPO BRANCH SHA
+create_or_update_branch() {
+  local repo="$1" branch="$2" sha="$3"
+  gh api "repos/${repo}/git/refs" \
+    --method POST \
+    --field "ref=refs/heads/${branch}" \
+    --field "sha=${sha}" || {
+    echo "Branch ${branch} already exists. Updating."
+    gh api "repos/${repo}/git/refs/heads/${branch}" \
+      --method PATCH \
+      --field "sha=${sha}"
+  }
+}
+
+# Echo the number of an open PR for the given head branch, or empty.
+# Usage: existing_open_pr REPO BRANCH
+existing_open_pr() {
+  gh pr list --repo "$1" --head "$2" --state open --json number --jq '.[0].number // empty'
+}
+
+# Echo the PR-body line describing a dependency bump. On public repos the
+# alert link is omitted — it discloses the package, CVE, and severity
+# before a fix is out. Usage: bump_alert_line REPO PACKAGE VERSION ALERT
+bump_alert_line() {
+  local repo="$1" package="$2" version="$3" alert="$4"
+  local visibility
+  visibility=$(gh api "repos/${repo}" --jq '.visibility')
+  if [ "$visibility" = "public" ]; then
+    echo "Resolves a flagged transitive dependency advisory."
+  else
+    echo "Bumps **${package}** to \`${version:-latest}\` to resolve [Dependabot alert #${alert}](https://github.com/${repo}/security/dependabot/${alert})."
+  fi
+}

--- a/tests/scripts/test_extract_alert_verdict.py
+++ b/tests/scripts/test_extract_alert_verdict.py
@@ -53,6 +53,19 @@ def test_json_session_log():
     assert extract(log) == VERDICT
 
 
+def test_json_log_with_stderr_noise_and_result_event():
+    """Real-world case: 2>&1 prepends a trust warning, and the verdict
+    lives in the result event of a single-line JSON stream."""
+    text = "I have enough evidence.\n```VERDICT_JSON\n" + json.dumps(VERDICT) + "\n```"
+    events = [
+        {"type": "system", "subtype": "init"},
+        {"type": "result", "subtype": "success", "result": text},
+    ]
+    log = "Ignoring 3 permissions.allow entries: workspace not trusted.\n"
+    log += json.dumps(events)
+    assert extract(log) == VERDICT
+
+
 def test_no_verdict_returns_none():
     assert extract("No verdict here.") is None
     assert extract("[]") is None


### PR DESCRIPTION
Affected-alert remediation landed as a bare commit on the temporary advisory fork with no PR, so there was nothing to review. Add fork-fix-pr.sh to open a pull request inside the private fork, where it stays scoped to advisory collaborators.

Unaffected transitive bump PRs linked the Dependabot alert in their body. On a public target repo that link discloses the package, CVE, and severity. Gate the alert link on repo visibility.