### PR TITLE
fix: upload hidden .blender-context artifact

### DIFF
--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -83,6 +83,7 @@ jobs:
           name: blender-context
           path: target/.blender-context/
           retention-days: 14
+          include-hidden-files: true
 
       - name: Warn about CircleCI
         if: steps.gather.outputs.HAS_CIRCLECI_FAILURE == 'true'


### PR DESCRIPTION
The gather step writes context into .blender-context/, a hidden directory. Since upload-artifact v4, hidden files are excluded by default, so the upload found no files and skipped the artifact. This left maintainers with nothing to inspect when a fix run went wrong.

Set include-hidden-files: true, matching the alert-verdict upload in investigate-security-alert.yml.