### PR TITLE
fix(setup): create the config commit via the GitHub API so it is verified

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -104,7 +104,27 @@ jobs:
           fi
 
           git commit -m "feat: add BLEnder config"
+
+          # Push the branch to upload the tree and blobs, then replace the tip
+          # with a commit created via the GitHub API. API-created commits are
+          # GitHub-signed (Verified), which repos that enable "Require signed
+          # commits" branch protection (e.g. mozilla/fxa) require in order to
+          # merge. git builds the tree locally, so file modes — including the
+          # symlinks created by setup.sh — are preserved.
           git push --force-with-lease origin "$BRANCH"
+
+          TREE=$(git rev-parse "HEAD^{tree}")
+          PARENT=$(git rev-parse "HEAD^")
+          VERIFIED_SHA=$(gh api "repos/${REPO}/git/commits" \
+            --method POST \
+            -f "message=feat: add BLEnder config" \
+            -f "tree=${TREE}" \
+            -f "parents[]=${PARENT}" \
+            --jq '.sha')
+          gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+            --method PATCH \
+            -f "sha=${VERIFIED_SHA}" \
+            -F "force=true"
 
           # Check for existing PR (reuse branch-exists result)
           if [ "$BRANCH_EXISTS" = "true" ]; then
@@ -137,3 +157,4 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ inputs.target_repo }}

--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -65,23 +65,11 @@ jobs:
             echo "Error: Setup did not generate config at .blender/"
             exit 1
           fi
-          git config user.name "blender[bot]"
-          git config user.email "blender[bot]@users.noreply.github.com"
+          # shellcheck source=scripts/pr-lib.sh
+          source "${BLENDER_DIR}/scripts/pr-lib.sh"
+          require_token_repo
 
           BRANCH="blender-setup"
-
-          # Handle re-runs: check for existing branch
-          BRANCH_EXISTS=false
-          if git ls-remote --exit-code origin "$BRANCH" >/dev/null 2>&1; then
-            BRANCH_EXISTS=true
-          fi
-
-          if [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "Branch $BRANCH already exists on remote. Force-pushing update."
-            git checkout -B "$BRANCH"
-          else
-            git checkout -b "$BRANCH"
-          fi
 
           # Stage .blender/ directory
           git add .blender/
@@ -103,35 +91,22 @@ jobs:
             exit 0
           fi
 
-          git commit -m "feat: add BLEnder config"
+          # Create a verified commit via the GitHub API, then point the branch
+          # at it. API commits are GitHub-signed (Verified), which repos that
+          # require signed commits (e.g. mozilla/fxa) need in order to merge.
+          # git-commit-api.sh preserves symlink modes via readlink.
+          PARENT=$(git rev-parse HEAD)
+          mapfile -t FILES < <(git diff --cached --name-only)
+          COMMIT=$("${BLENDER_DIR}/scripts/git-commit-api.sh" \
+            "feat: add BLEnder config" "$PARENT" "${FILES[@]}")
 
-          # Push the branch to upload the tree and blobs, then replace the tip
-          # with a commit created via the GitHub API. API-created commits are
-          # GitHub-signed (Verified), which repos that enable "Require signed
-          # commits" branch protection (e.g. mozilla/fxa) require in order to
-          # merge. git builds the tree locally, so file modes — including the
-          # symlinks created by setup.sh — are preserved.
-          git push --force-with-lease origin "$BRANCH"
+          # Create the branch, or force it to the new commit on re-runs.
+          gh api "repos/${REPO}/git/refs" --method POST \
+            -f "ref=refs/heads/${BRANCH}" -f "sha=${COMMIT}" 2>/dev/null || \
+          gh api "repos/${REPO}/git/refs/heads/${BRANCH}" --method PATCH \
+            -f "sha=${COMMIT}" -F "force=true"
 
-          TREE=$(git rev-parse "HEAD^{tree}")
-          PARENT=$(git rev-parse "HEAD^")
-          VERIFIED_SHA=$(gh api "repos/${REPO}/git/commits" \
-            --method POST \
-            -f "message=feat: add BLEnder config" \
-            -f "tree=${TREE}" \
-            -f "parents[]=${PARENT}" \
-            --jq '.sha')
-          gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
-            --method PATCH \
-            -f "sha=${VERIFIED_SHA}" \
-            -F "force=true"
-
-          # Check for existing PR (reuse branch-exists result)
-          if [ "$BRANCH_EXISTS" = "true" ]; then
-            existing_pr=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty' 2>/dev/null || true)
-          else
-            existing_pr=""
-          fi
+          existing_pr=$(existing_open_pr "$REPO" "$BRANCH")
           if [ -n "$existing_pr" ]; then
             echo "PR #${existing_pr} already exists. Updated branch."
           else
@@ -158,3 +133,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ inputs.target_repo }}
+          BLENDER_DIR: ${{ github.workspace }}

--- a/scripts/git-commit-api.sh
+++ b/scripts/git-commit-api.sh
@@ -35,16 +35,31 @@ BASE_TREE=$(gh api "repos/${REPO}/git/commits/${PARENT}" --jq '.tree.sha')
 # Upload each file as a blob
 TREE_ITEMS="[]"
 for file in "${FILES[@]}"; do
-  BLOB_SHA=$(base64 -w 0 "$file" | \
-    jq -Rs '{"encoding": "base64", "content": .}' | \
-    gh api "repos/${REPO}/git/blobs" \
-    --method POST \
-    --input - \
-    --jq '.sha')
+  if [ -L "$file" ]; then
+    # Symlink: the blob content is the link target, with git mode 120000.
+    # Uploading it as a regular file (100644) would replace the link with a
+    # file containing the target path.
+    BLOB_SHA=$(printf '%s' "$(readlink "$file")" | \
+      jq -Rs '{"encoding": "utf-8", "content": .}' | \
+      gh api "repos/${REPO}/git/blobs" \
+      --method POST \
+      --input - \
+      --jq '.sha')
+    MODE="120000"
+  else
+    BLOB_SHA=$(base64 -w 0 "$file" | \
+      jq -Rs '{"encoding": "base64", "content": .}' | \
+      gh api "repos/${REPO}/git/blobs" \
+      --method POST \
+      --input - \
+      --jq '.sha')
+    MODE="100644"
+  fi
   TREE_ITEMS=$(echo "$TREE_ITEMS" | jq \
     --arg path "$file" \
     --arg sha "$BLOB_SHA" \
-    '. + [{"path": $path, "mode": "100644", "type": "blob", "sha": $sha}]')
+    --arg mode "$MODE" \
+    '. + [{"path": $path, "mode": $mode, "type": "blob", "sha": $sha}]')
 done
 
 # Create tree


### PR DESCRIPTION
Fixes #99.

**Problem:** The setup workflow commits `.blender` config with plain `git commit` + `git push`, so it's unsigned. Repos that require signed commits (e.g. `mozilla/fxa`) block the onboarding PR — see mozilla/fxa#20892. BLEnder's dependency commits are already `Verified` because they go through the GitHub API (`scripts/commit.sh`); only setup used the git path.

**Fix:** Commit locally so git builds the tree (preserving the symlink modes `setup.sh` creates), push to upload the blobs, then re-create the tip via the `git/commits` API and move the branch ref to it — API commits are GitHub-signed (`Verified`). Also exports `REPO` to the step env.

**Notes:**
- Let git build the tree rather than reuse `git-commit-api.sh` directly, since that helper hardcodes mode `100644` and would flatten setup's symlinks. Can make the shared helper symlink-aware instead if you'd prefer one path.
- Not run end-to-end (needs app creds); mirrors the API calls in `scripts/commit.sh`. Suggest a setup run on a repo with required signed commits to confirm the PR commit shows `Verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
