### PR TITLE
ci: run ruff via uv so it uses the locked version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
         with:
           persist-credentials: false
-      - name: Install ruff
-        run: pip install ruff
+      - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3  # v6
       - name: Run ruff check
-        run: ruff check scripts/
+        run: uv run --extra dev ruff check scripts/
       - name: Run ruff format check
-        run: ruff format --check scripts/
+        run: uv run --extra dev ruff format --check scripts/
 
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem
The `ruff` job installs ruff **unpinned** (`pip install ruff`), so it tracks the latest release — currently **0.16.0**, whose default rule set flags rules older ruff didn't (`EXE001`, `PLW1510`). Since `pyproject.toml` has no `[tool.ruff.lint] select`, a linter release silently widens the rule set and turns `main` red (47 findings in `scripts/*.py`) with no code change.

## Fix
Run ruff via `uv` using the locked `dev` extra (`ruff==0.15.20` in `uv.lock`), mirroring the `test` job. This gives ruff a single source of truth and lets Dependabot manage bumps (e.g. #96), so rule-set changes show up in a reviewable PR instead of appearing out of nowhere.

Restores the ruff version `main` was last green on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
