### PR TITLE
fix(investigate): install Python deps before load-config

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -65,6 +65,17 @@ jobs:
           install-sandbox: 'true'
           install-claude: 'true'
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v6
+
+      - name: Install Python dependencies
+        run: |
+          uv sync
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+
       - name: Check for existing BLEnder PR
         id: existing-pr
         run: |


### PR DESCRIPTION
Fixes #107.

The `investigate-security-alert` workflow ran `python scripts/load-config.py` with no Python deps installed → `ModuleNotFoundError: No module named 'yaml'`, failing every alert investigation (mozilla/fxa, mozilla/blurts-server).

Adds the same `setup-python` + `setup-uv` + `uv sync` steps that `chore-automerge-dependabot-prs.yml` already uses before its `load-config.py` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
