### PR TITLE
fix(automerge): use a repo-allowed merge method; surface enable_auto_merge errors

### DIFF
--- a/scripts/automerge_dependabot.py
+++ b/scripts/automerge_dependabot.py
@@ -602,7 +602,9 @@ def approve_and_merge(pr: PullRequest, compat_score: int | None) -> None:
         "no advisories)."
     )
     pr.create_review(event="APPROVE", body=review_body)
-    enable_auto_merge(pr)
+    error = enable_auto_merge(pr)
+    if error:
+        raise SkipPR(f"could not enable auto-merge: {error}")
 
 
 # --- Main ---

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -87,6 +87,28 @@ def has_codeowner_approval(pr: PullRequest) -> bool:
     return False
 
 
+_MERGE_METHOD_PREFERENCE = ("SQUASH", "MERGE", "REBASE")
+
+
+def _allowed_merge_method(pr: PullRequest) -> str:
+    """Return a merge method the target repo allows, preferring squash.
+
+    Hardcoding SQUASH fails on repos that disable squash merges (e.g.
+    merge-commit-only repos like mozilla/fxa), so fall back to whatever
+    the repo actually permits.
+    """
+    repo = pr.base.repo
+    allowed = {
+        "SQUASH": repo.allow_squash_merge,
+        "MERGE": repo.allow_merge_commit,
+        "REBASE": repo.allow_rebase_merge,
+    }
+    for method in _MERGE_METHOD_PREFERENCE:
+        if allowed.get(method):
+            return method
+    return "MERGE"
+
+
 def enable_auto_merge(pr: PullRequest) -> str | None:
     """Enable auto-merge on a PR via the GraphQL API.
 
@@ -96,10 +118,16 @@ def enable_auto_merge(pr: PullRequest) -> str | None:
     GITHUB_TOKEN in Actions doesn't have with branch protection.
     The GraphQL enablePullRequestAutoMerge mutation works with the
     standard token and lets GitHub merge once protection rules pass.
+
+    Uses a merge method the repo allows (see _allowed_merge_method);
+    hardcoding SQUASH fails on repos that only allow merge commits.
     """
+    method = _allowed_merge_method(pr)
     query = """
-    mutation EnableAutoMerge($prId: ID!) {
-      enablePullRequestAutoMerge(input: {pullRequestId: $prId, mergeMethod: SQUASH}) {
+    mutation EnableAutoMerge($prId: ID!, $method: PullRequestMergeMethod!) {
+      enablePullRequestAutoMerge(
+        input: {pullRequestId: $prId, mergeMethod: $method}
+      ) {
         pullRequest { autoMergeRequest { enabledAt } }
       }
     }
@@ -107,7 +135,10 @@ def enable_auto_merge(pr: PullRequest) -> str | None:
     _, data = pr._requester.requestJsonAndCheck(
         "POST",
         "/graphql",
-        input={"query": query, "variables": {"prId": pr.node_id}},
+        input={
+            "query": query,
+            "variables": {"prId": pr.node_id, "method": method},
+        },
     )
     errors = data.get("errors")
     if errors:

--- a/tests/scripts/test_automerge_dependabot.py
+++ b/tests/scripts/test_automerge_dependabot.py
@@ -19,6 +19,7 @@ from scripts.automerge_dependabot import (
     SkipPR,
     _normalize_pep440_range,
     _post_dependabot_recreate,
+    approve_and_merge,
     extract_metadata,
     gate_advisories,
     gate_compatibility,
@@ -26,7 +27,12 @@ from scripts.automerge_dependabot import (
     main,
     version_in_range,
 )
-from scripts.github_utils import Verdict, has_blender_verdict, has_codeowner_approval
+from scripts.github_utils import (
+    Verdict,
+    _allowed_merge_method,
+    has_blender_verdict,
+    has_codeowner_approval,
+)
 
 
 # --- _normalize_pep440_range ---
@@ -630,3 +636,51 @@ def test_gate_compatibility_raises_when_dep_has_no_old_version():
 
     with pytest.raises(RetryPR, match="no compatibility badge"):
         gate_compatibility(pr, meta)
+
+
+# --- _allowed_merge_method ---
+
+
+class TestAllowedMergeMethod:
+    """Pick a merge method the repo allows; prefer SQUASH, then MERGE, REBASE."""
+
+    @staticmethod
+    def _pr(squash: bool, merge: bool, rebase: bool) -> MagicMock:
+        pr = MagicMock()
+        pr.base.repo.allow_squash_merge = squash
+        pr.base.repo.allow_merge_commit = merge
+        pr.base.repo.allow_rebase_merge = rebase
+        return pr
+
+    def test_prefers_squash_when_allowed(self):
+        assert _allowed_merge_method(self._pr(True, True, True)) == "SQUASH"
+
+    def test_falls_back_to_merge_when_squash_disabled(self):
+        # e.g. mozilla/fxa: merge-commit-only.
+        assert _allowed_merge_method(self._pr(False, True, False)) == "MERGE"
+
+    def test_falls_back_to_rebase_when_only_rebase(self):
+        assert _allowed_merge_method(self._pr(False, False, True)) == "REBASE"
+
+    def test_defaults_to_merge_when_none_allowed(self):
+        assert _allowed_merge_method(self._pr(False, False, False)) == "MERGE"
+
+
+# --- approve_and_merge surfaces enable_auto_merge errors ---
+
+
+@patch("scripts.automerge_dependabot.enable_auto_merge")
+def test_approve_and_merge_raises_skippr_on_enable_error(mock_enable):
+    mock_enable.return_value = "Pull request is in clean status"
+    pr = MagicMock()
+    with pytest.raises(SkipPR, match="could not enable auto-merge"):
+        approve_and_merge(pr, compat_score=90)
+    pr.create_review.assert_called_once()
+
+
+@patch("scripts.automerge_dependabot.enable_auto_merge")
+def test_approve_and_merge_succeeds_when_enable_returns_none(mock_enable):
+    mock_enable.return_value = None
+    pr = MagicMock()
+    approve_and_merge(pr, compat_score=90)
+    pr.create_review.assert_called_once()


### PR DESCRIPTION
Fixes #109.

## Problem
`enable_auto_merge` hardcodes `mergeMethod: SQUASH`, which fails on repos that disable squash merges (e.g. `mozilla/fxa`, merge-commit-only). `approve_and_merge` ignores the returned error and logs `Auto-merge enabled` regardless, so PRs are approved but never auto-merge — silently.

## Fix
- `github_utils.py`: add `_allowed_merge_method()` — pick a method the repo permits (prefer `SQUASH`, else `MERGE`, else `REBASE`) and pass it to the mutation as a variable.
- `automerge_dependabot.py`: `approve_and_merge` now checks `enable_auto_merge`'s return and raises `SkipPR(...)` with the real error, so a failure is reported honestly instead of logged as success.

## Testing
Not run in the Actions context (needs app creds). Both files `py_compile` clean. Behavior on squash-enabled repos is unchanged (SQUASH is still preferred); merge-commit-only repos now fall back to `MERGE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
