### PR TITLE
fix(investigate): skip npm bump on yarn/pnpm repos instead of failing (breaks re-investigation loop)

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -188,11 +188,6 @@ jobs:
         if: steps.post-action.outputs.action == 'npm_bump'
         working-directory: target
         run: |
-          # The npm bump path is npm-only (npm audit fix + package-lock.json).
-          # On yarn/pnpm repos there is no package-lock.json, so npm-bump.sh
-          # fails and the job errors — which means the alert never gets tagged
-          # and the sweep re-investigates it forever (#111). Skip gracefully so
-          # the job succeeds and the alert is marked investigated.
           if [ ! -f package-lock.json ]; then
             echo "::warning ::No package-lock.json (yarn/pnpm repo) — npm bump unsupported; skipping (see #111)."
             echo "fixed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -188,6 +188,16 @@ jobs:
         if: steps.post-action.outputs.action == 'npm_bump'
         working-directory: target
         run: |
+          # The npm bump path is npm-only (npm audit fix + package-lock.json).
+          # On yarn/pnpm repos there is no package-lock.json, so npm-bump.sh
+          # fails and the job errors — which means the alert never gets tagged
+          # and the sweep re-investigates it forever (#111). Skip gracefully so
+          # the job succeeds and the alert is marked investigated.
+          if [ ! -f package-lock.json ]; then
+            echo "::warning ::No package-lock.json (yarn/pnpm repo) — npm bump unsupported; skipping (see #111)."
+            echo "fixed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "Before fix — vulnerable instances:"
           npm ls "$NPM_PACKAGE" --all 2>/dev/null || true
           echo "---"


### PR DESCRIPTION
Fixes #111.

On repos without `package-lock.json` (yarn/pnpm, e.g. mozilla/fxa), the npm-bump remediation runs `npm audit fix` + `npm-bump.sh` and **fails** (`ENOLOCK` / `base64: package-lock.json: No such file`). Because the remediate job errors, the alert is never tagged `investigated/…`, so the scheduled sweep re-investigates it every cycle — a runaway loop.

This makes the `Run npm audit fix` step **detect the absence of `package-lock.json` and skip gracefully** (`fixed=false`, exit 0). The bump-PR step is then skipped, the job succeeds, the alert gets tagged, and the loop stops. Full yarn support (resolutions) can come later; this stops the bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)