### PR TITLE
feat(investigate): add yarn Berry remediation path (#122)

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -229,6 +229,30 @@ jobs:
           REPO: ${{ inputs.target_repo }}
           GH_TOKEN: ${{ steps.setup.outputs.token }}
 
+      # --- yarn transitive dependency bump (Berry v2+; see #122) ---
+      - name: Run yarn upgrade
+        id: yarn-fix
+        if: steps.post-action.outputs.action == 'yarn_bump'
+        working-directory: target
+        run: bash ${{ github.workspace }}/scripts/yarn-fix.sh
+        env:
+          YARN_PACKAGE: ${{ steps.post-action.outputs.yarn_package }}
+          YARN_VERSION: ${{ steps.post-action.outputs.yarn_version }}
+
+      - name: Create yarn bump PR
+        if: >-
+          steps.post-action.outputs.action == 'yarn_bump'
+          && steps.yarn-fix.outputs.fixed == 'true'
+          && inputs.dry_run != 'true'
+        working-directory: target
+        run: bash ${{ github.workspace }}/scripts/yarn-bump.sh
+        env:
+          PACKAGE: ${{ steps.post-action.outputs.yarn_package }}
+          PATCHED_VERSION: ${{ steps.post-action.outputs.yarn_version }}
+          ALERT_NUMBER: ${{ inputs.alert_number }}
+          REPO: ${{ inputs.target_repo }}
+          GH_TOKEN: ${{ steps.setup.outputs.token }}
+
       # --- pip transitive dependency bump (lock file only) ---
       - name: Run pip lock upgrade
         id: pip-fix

--- a/scripts/npm-bump.sh
+++ b/scripts/npm-bump.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
-# BLEnder npm bump: commit package-lock.json changes via verified commit
-# and open a PR.
+# BLEnder npm bump: commit package-lock.json changes via a verified commit and
+# open a PR. Runs after `npm audit fix` in the target repo checkout.
 #
-# Runs after `npm audit fix` in the target repo checkout.
-# Delegates blob -> tree -> commit to git-commit-api.sh.
-#
-# Environment variables:
-#   GH_TOKEN          -- GitHub token (required, also used as GH_TOKEN for gh cli)
-#   PACKAGE           -- npm package name (required)
-#   PATCHED_VERSION   -- version to bump to (required)
-#   ALERT_NUMBER      -- Dependabot alert number (required)
-#   REPO              -- target repo, e.g. mozilla/blurts-server (required)
+#   GH_TOKEN, PACKAGE, PATCHED_VERSION, ALERT_NUMBER, REPO
 
 set -euo pipefail
 
@@ -18,71 +10,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/pr-lib.sh
 source "${SCRIPT_DIR}/pr-lib.sh"
 
-require_token_repo
-
-if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
-  echo "Error: PACKAGE and ALERT_NUMBER are required."
-  exit 1
-fi
-
-# Check that package-lock.json changed
-if git diff --quiet package-lock.json 2>/dev/null; then
-  echo "package-lock.json unchanged after npm audit fix. Nothing to do."
-  exit 0
-fi
-
-BRANCH_NAME="blender/security-bump-${PACKAGE}"
-
-# Check for existing open PR on this branch — exit before any API calls
-EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
-if [ -n "$EXISTING_PR" ]; then
-  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
-  exit 0
-fi
-
-COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
-
-Resolves Dependabot alert #${ALERT_NUMBER}.
-Created by BLEnder (https://github.com/mozilla/blender)"
-
-DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
-PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
-
-# Collect changed files
-CHANGED_FILES=()
-for file in package-lock.json package.json; do
-  if ! git diff --quiet "$file" 2>/dev/null; then
-    CHANGED_FILES+=("$file")
-  fi
-done
-
-COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
-
-# Create branch ref
-create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
-
-echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
-
-# Build PR body
-RUN_LINK=$(run_link)
-ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
-
-PR_BODY="## Summary
-
-${ALERT_LINE}
-
-This is a transitive dependency update. Only \`package-lock.json\` (and possibly \`package.json\`) changed.
-
----
-*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
-
-PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
-
-gh pr create \
-  --repo "$REPO" \
-  --head "$BRANCH_NAME" \
-  --base "$DEFAULT_BRANCH" \
-  --title "$PR_TITLE" \
-  --body "$PR_BODY"
-
-echo "PR created."
+open_bump_pr package-lock.json

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -503,8 +503,6 @@ def main() -> None:
             action = "dismissed"
         elif recommended == "bump_pr":
             if ecosystem == "npm" and patched_version:
-                # npm and yarn share the npm_and_yarn ecosystem; the lockfile
-                # decides which bump path to take.
                 pkg_manager = detect_js_package_manager(repo)
                 if pkg_manager == "yarn":
                     print("  yarn ecosystem — deferring to yarn_bump workflow step.")
@@ -519,7 +517,6 @@ def main() -> None:
                     write_output("npm_version", patched_version)
                     write_output("alert_number", str(alert_number))
                 else:
-                    # pnpm or no lockfile — no supported bump path yet (#122).
                     print(
                         f"  JS package manager '{pkg_manager}' has no bump path. "
                         "No action."

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -504,17 +504,14 @@ def main() -> None:
         elif recommended == "bump_pr":
             if ecosystem == "npm" and patched_version:
                 pkg_manager = detect_js_package_manager(repo)
-                if pkg_manager == "yarn":
-                    print("  yarn ecosystem — deferring to yarn_bump workflow step.")
-                    action = "yarn_bump"
-                    write_output("yarn_package", package_name)
-                    write_output("yarn_version", patched_version)
-                    write_output("alert_number", str(alert_number))
-                elif pkg_manager == "npm":
-                    print("  npm ecosystem — deferring to npm_bump workflow step.")
-                    action = "npm_bump"
-                    write_output("npm_package", package_name)
-                    write_output("npm_version", patched_version)
+                if pkg_manager in ("npm", "yarn"):
+                    print(
+                        f"  {pkg_manager} ecosystem — deferring to "
+                        f"{pkg_manager}_bump workflow step."
+                    )
+                    action = f"{pkg_manager}_bump"
+                    write_output(f"{pkg_manager}_package", package_name)
+                    write_output(f"{pkg_manager}_version", patched_version)
                     write_output("alert_number", str(alert_number))
                 else:
                     print(

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -399,6 +399,28 @@ def detect_pip_lock_tool(
     return None
 
 
+def detect_js_package_manager(repo) -> str | None:
+    """Detect the JS package manager from the lockfile present.
+
+    Dependabot reports npm and yarn alerts under one ecosystem
+    (``npm_and_yarn``), so the lockfile is what tells them apart.
+    Returns "npm", "yarn", "pnpm", or None if no JS lockfile is found.
+    """
+    lock_files = {
+        "package-lock.json": "npm",
+        "yarn.lock": "yarn",
+        "pnpm-lock.yaml": "pnpm",
+    }
+    for lock_file, manager in lock_files.items():
+        try:
+            repo.get_contents(lock_file)
+            print(f"  Found {lock_file} — {manager}")
+            return manager
+        except Exception:
+            continue
+    return None
+
+
 def dismiss_alert(
     repo,
     alert_number: int,
@@ -481,11 +503,28 @@ def main() -> None:
             action = "dismissed"
         elif recommended == "bump_pr":
             if ecosystem == "npm" and patched_version:
-                print("  npm ecosystem — deferring to npm_bump workflow step.")
-                action = "npm_bump"
-                write_output("npm_package", package_name)
-                write_output("npm_version", patched_version)
-                write_output("alert_number", str(alert_number))
+                # npm and yarn share the npm_and_yarn ecosystem; the lockfile
+                # decides which bump path to take.
+                pkg_manager = detect_js_package_manager(repo)
+                if pkg_manager == "yarn":
+                    print("  yarn ecosystem — deferring to yarn_bump workflow step.")
+                    action = "yarn_bump"
+                    write_output("yarn_package", package_name)
+                    write_output("yarn_version", patched_version)
+                    write_output("alert_number", str(alert_number))
+                elif pkg_manager == "npm":
+                    print("  npm ecosystem — deferring to npm_bump workflow step.")
+                    action = "npm_bump"
+                    write_output("npm_package", package_name)
+                    write_output("npm_version", patched_version)
+                    write_output("alert_number", str(alert_number))
+                else:
+                    # pnpm or no lockfile — no supported bump path yet (#122).
+                    print(
+                        f"  JS package manager '{pkg_manager}' has no bump path. "
+                        "No action."
+                    )
+                    action = "noop"
             elif ecosystem == "npm":
                 print("  npm ecosystem but no patched version. Cannot bump.")
                 action = "noop"

--- a/scripts/pr-lib.sh
+++ b/scripts/pr-lib.sh
@@ -77,3 +77,78 @@ bump_alert_line() {
     echo "Bumps **${package}** to \`${version:-latest}\` to resolve [Dependabot alert #${alert}](https://github.com/${repo}/security/dependabot/${alert})."
   fi
 }
+
+# Commit a dependency bump (lockfile + package.json) via a verified commit and
+# open a PR. npm-bump.sh and yarn-bump.sh differ only in which lockfile they
+# touch, so both call this. Usage: open_bump_pr LOCKFILE
+#   env: GH_TOKEN, PACKAGE, PATCHED_VERSION, ALERT_NUMBER, REPO
+open_bump_pr() {
+  local lockfile="$1"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  require_token_repo
+
+  if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
+    echo "Error: PACKAGE and ALERT_NUMBER are required."
+    exit 1
+  fi
+
+  if git diff --quiet "$lockfile" 2>/dev/null; then
+    echo "${lockfile} unchanged after fix. Nothing to do."
+    exit 0
+  fi
+
+  local branch="blender/security-bump-${PACKAGE}"
+
+  local existing
+  existing=$(existing_open_pr "$REPO" "$branch")
+  if [ -n "$existing" ]; then
+    echo "PR #${existing} already open for ${branch}. Skipping."
+    exit 0
+  fi
+
+  local commit_msg="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+
+Resolves Dependabot alert #${ALERT_NUMBER}.
+Created by BLEnder (https://github.com/mozilla/blender)"
+
+  local default_branch parent
+  default_branch=$(gh api "repos/${REPO}" --jq '.default_branch')
+  parent=$(gh api "repos/${REPO}/git/ref/heads/${default_branch}" --jq '.object.sha')
+
+  local changed_files=() file
+  for file in "$lockfile" package.json; do
+    if ! git diff --quiet "$file" 2>/dev/null; then
+      changed_files+=("$file")
+    fi
+  done
+
+  local commit_sha
+  commit_sha=$("${script_dir}/git-commit-api.sh" "$commit_msg" "$parent" "${changed_files[@]}")
+
+  create_or_update_branch "$REPO" "$branch" "$commit_sha"
+  echo "Created branch ${branch} with commit ${commit_sha}"
+
+  local run_link_md alert_line
+  run_link_md=$(run_link)
+  alert_line=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
+
+  local pr_body="## Summary
+
+${alert_line}
+
+This is a transitive dependency update. Only \`${lockfile}\` (and possibly \`package.json\`) changed.
+
+---
+*Created by ${run_link_md} via [BLEnder](https://github.com/mozilla/blender)*"
+
+  gh pr create \
+    --repo "$REPO" \
+    --head "$branch" \
+    --base "$default_branch" \
+    --title "chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}" \
+    --body "$pr_body"
+
+  echo "PR created."
+}

--- a/scripts/yarn-bump.sh
+++ b/scripts/yarn-bump.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
-# BLEnder yarn bump: commit yarn.lock (+ package.json) changes via a verified
-# commit and open a PR. Runs after scripts/yarn-fix.sh in the target checkout.
+# BLEnder yarn bump: commit yarn.lock changes via verified commit and open a PR.
+# Runs after scripts/yarn-fix.sh in the target repo checkout. Mirrors npm-bump.sh.
 #
-# Mirrors npm-bump.sh; delegates blob -> tree -> commit to git-commit-api.sh.
-# See #122.
-#
-# Environment variables:
 #   GH_TOKEN          -- GitHub token (required, also used by gh cli)
 #   PACKAGE           -- yarn package name (required)
 #   PATCHED_VERSION   -- version to bump to (optional)
@@ -25,7 +21,6 @@ if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
   exit 1
 fi
 
-# Check that yarn.lock changed
 if git diff --quiet yarn.lock 2>/dev/null; then
   echo "yarn.lock unchanged after yarn up. Nothing to do."
   exit 0
@@ -33,7 +28,6 @@ fi
 
 BRANCH_NAME="blender/security-bump-${PACKAGE}"
 
-# Check for existing open PR on this branch — exit before any API calls
 EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
 if [ -n "$EXISTING_PR" ]; then
   echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
@@ -48,8 +42,6 @@ Created by BLEnder (https://github.com/mozilla/blender)"
 DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
 PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
 
-# Collect changed files. NOTE: PnP repos may also change .pnp.cjs and
-# .yarn/cache/* — not handled here yet (see #122).
 CHANGED_FILES=()
 for file in yarn.lock package.json; do
   if ! git diff --quiet "$file" 2>/dev/null; then
@@ -59,12 +51,9 @@ done
 
 COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
 
-# Create branch ref
 create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
-
 echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
 
-# Build PR body
 RUN_LINK=$(run_link)
 ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
 

--- a/scripts/yarn-bump.sh
+++ b/scripts/yarn-bump.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-# BLEnder yarn bump: commit yarn.lock changes via verified commit and open a PR.
-# Runs after scripts/yarn-fix.sh in the target repo checkout. Mirrors npm-bump.sh.
+# BLEnder yarn bump: commit yarn.lock changes via a verified commit and open a
+# PR. Runs after scripts/yarn-fix.sh in the target repo checkout.
 #
-#   GH_TOKEN          -- GitHub token (required, also used by gh cli)
-#   PACKAGE           -- yarn package name (required)
-#   PATCHED_VERSION   -- version to bump to (optional)
-#   ALERT_NUMBER      -- Dependabot alert number (required)
-#   REPO              -- target repo, e.g. mozilla/fxa (required)
+#   GH_TOKEN, PACKAGE, PATCHED_VERSION, ALERT_NUMBER, REPO
 
 set -euo pipefail
 
@@ -14,65 +10,4 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/pr-lib.sh
 source "${SCRIPT_DIR}/pr-lib.sh"
 
-require_token_repo
-
-if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
-  echo "Error: PACKAGE and ALERT_NUMBER are required."
-  exit 1
-fi
-
-if git diff --quiet yarn.lock 2>/dev/null; then
-  echo "yarn.lock unchanged after yarn up. Nothing to do."
-  exit 0
-fi
-
-BRANCH_NAME="blender/security-bump-${PACKAGE}"
-
-EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
-if [ -n "$EXISTING_PR" ]; then
-  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
-  exit 0
-fi
-
-COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
-
-Resolves Dependabot alert #${ALERT_NUMBER}.
-Created by BLEnder (https://github.com/mozilla/blender)"
-
-DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
-PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
-
-CHANGED_FILES=()
-for file in yarn.lock package.json; do
-  if ! git diff --quiet "$file" 2>/dev/null; then
-    CHANGED_FILES+=("$file")
-  fi
-done
-
-COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
-
-create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
-echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
-
-RUN_LINK=$(run_link)
-ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
-
-PR_BODY="## Summary
-
-${ALERT_LINE}
-
-This is a transitive dependency update. Only \`yarn.lock\` (and possibly \`package.json\`) changed.
-
----
-*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
-
-PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
-
-gh pr create \
-  --repo "$REPO" \
-  --head "$BRANCH_NAME" \
-  --base "$DEFAULT_BRANCH" \
-  --title "$PR_TITLE" \
-  --body "$PR_BODY"
-
-echo "PR created."
+open_bump_pr yarn.lock

--- a/scripts/yarn-bump.sh
+++ b/scripts/yarn-bump.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# BLEnder yarn bump: commit yarn.lock (+ package.json) changes via a verified
+# commit and open a PR. Runs after scripts/yarn-fix.sh in the target checkout.
+#
+# Mirrors npm-bump.sh; delegates blob -> tree -> commit to git-commit-api.sh.
+# See #122.
+#
+# Environment variables:
+#   GH_TOKEN          -- GitHub token (required, also used by gh cli)
+#   PACKAGE           -- yarn package name (required)
+#   PATCHED_VERSION   -- version to bump to (optional)
+#   ALERT_NUMBER      -- Dependabot alert number (required)
+#   REPO              -- target repo, e.g. mozilla/fxa (required)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/pr-lib.sh
+source "${SCRIPT_DIR}/pr-lib.sh"
+
+require_token_repo
+
+if [ -z "${PACKAGE:-}" ] || [ -z "${ALERT_NUMBER:-}" ]; then
+  echo "Error: PACKAGE and ALERT_NUMBER are required."
+  exit 1
+fi
+
+# Check that yarn.lock changed
+if git diff --quiet yarn.lock 2>/dev/null; then
+  echo "yarn.lock unchanged after yarn up. Nothing to do."
+  exit 0
+fi
+
+BRANCH_NAME="blender/security-bump-${PACKAGE}"
+
+# Check for existing open PR on this branch — exit before any API calls
+EXISTING_PR=$(existing_open_pr "$REPO" "$BRANCH_NAME")
+if [ -n "$EXISTING_PR" ]; then
+  echo "PR #${EXISTING_PR} already open for ${BRANCH_NAME}. Skipping."
+  exit 0
+fi
+
+COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+
+Resolves Dependabot alert #${ALERT_NUMBER}.
+Created by BLEnder (https://github.com/mozilla/blender)"
+
+DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
+PARENT=$(gh api "repos/${REPO}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha')
+
+# Collect changed files. NOTE: PnP repos may also change .pnp.cjs and
+# .yarn/cache/* — not handled here yet (see #122).
+CHANGED_FILES=()
+for file in yarn.lock package.json; do
+  if ! git diff --quiet "$file" 2>/dev/null; then
+    CHANGED_FILES+=("$file")
+  fi
+done
+
+COMMIT_SHA=$("${SCRIPT_DIR}/git-commit-api.sh" "$COMMIT_MSG" "$PARENT" "${CHANGED_FILES[@]}")
+
+# Create branch ref
+create_or_update_branch "$REPO" "$BRANCH_NAME" "$COMMIT_SHA"
+
+echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
+
+# Build PR body
+RUN_LINK=$(run_link)
+ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
+
+PR_BODY="## Summary
+
+${ALERT_LINE}
+
+This is a transitive dependency update. Only \`yarn.lock\` (and possibly \`package.json\`) changed.
+
+---
+*Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
+
+PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
+
+gh pr create \
+  --repo "$REPO" \
+  --head "$BRANCH_NAME" \
+  --base "$DEFAULT_BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY"
+
+echo "PR created."

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -1,19 +1,9 @@
 #!/usr/bin/env bash
-# BLEnder yarn fix (yarn Berry v2+): bump a (possibly transitive) dependency
-# to a patched version and regenerate yarn.lock.
+# BLEnder yarn fix (Berry v2+): bump a dependency and update yarn.lock only.
+# Writes fixed=true|false to $GITHUB_OUTPUT. Classic yarn v1 is not supported.
 #
-# MVP scope (see #122):
-#   - Targets yarn Berry (v2+). Yarn classic (v1) is NOT handled yet.
-#   - Uses `yarn up -R` to raise the package everywhere it resolves in the
-#     dependency tree (including transitively), then regenerates yarn.lock.
-#   - Verification via `yarn npm audit` is best-effort only; `fixed` is based
-#     on `yarn up` succeeding. See OPEN QUESTIONS in the PR before relying on it.
-#
-# Runs in the target repo checkout. Writes `fixed=true|false` to $GITHUB_OUTPUT.
-#
-# Environment variables:
 #   YARN_PACKAGE  -- package name (required)
-#   YARN_VERSION  -- patched version to bump to (optional; latest if unset)
+#   YARN_VERSION  -- patched version, used only in messages (optional)
 
 set -euo pipefail
 
@@ -27,8 +17,6 @@ if [ ! -f yarn.lock ]; then
   exit 0
 fi
 
-# Berry is delivered through corepack; enable it so the repo's pinned yarn
-# (packageManager in package.json / .yarnrc.yml) is the one that runs.
 corepack enable 2>/dev/null || true
 
 YARN_VER="$(yarn --version 2>/dev/null || echo 0)"
@@ -41,16 +29,9 @@ case "$YARN_VER" in
     ;;
 esac
 
-echo "Before — where ${YARN_PACKAGE} resolves:"
 yarn why "$YARN_PACKAGE" 2>/dev/null || true
 
-# Berry v4's `-R` (recursive — covers transitive deps) takes the package NAME
-# only: it re-resolves every occurrence to the newest version satisfying each
-# existing range. Passing a version/range errors ("Ranges aren't allowed when
-# using --recursive"). --mode=update-lockfile writes yarn.lock without
-# installing, mirroring npm's --package-lock-only. Verified live against
-# mozilla/fxa (yarn@4.9.2): a single run bumped all vulnerable brace-expansion
-# lines to their patched in-range versions, yarn.lock-only.
+# `-R` (recursive) takes the name only — a version or range is rejected.
 echo "Running: yarn up -R ${YARN_PACKAGE} --mode=update-lockfile"
 if ! yarn up -R "$YARN_PACKAGE" --mode=update-lockfile; then
   echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; leaving for manual remediation."
@@ -58,15 +39,11 @@ if ! yarn up -R "$YARN_PACKAGE" --mode=update-lockfile; then
   exit 0
 fi
 
-# -R stays within the ranges declared by consumers. If the patched version is
-# outside every consumer's range (e.g. needs a major bump they don't allow),
-# yarn.lock won't change — that case needs a `resolutions` override, which is
-# not implemented yet (see #122).
 if git diff --quiet yarn.lock 2>/dev/null; then
   echo "::warning ::yarn.lock unchanged — ${YARN_PACKAGE} likely needs a resolutions override to reach ${YARN_VERSION:-the patched version} (see #122)."
   out fixed false
   exit 0
 fi
 
-echo "yarn.lock updated for ${YARN_PACKAGE} (advisory verified via CI / Dependabot)."
+echo "yarn.lock updated for ${YARN_PACKAGE}."
 out fixed true

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# BLEnder yarn fix (yarn Berry v2+): bump a (possibly transitive) dependency
+# to a patched version and regenerate yarn.lock.
+#
+# MVP scope (see #122):
+#   - Targets yarn Berry (v2+). Yarn classic (v1) is NOT handled yet.
+#   - Uses `yarn up -R` to raise the package everywhere it resolves in the
+#     dependency tree (including transitively), then regenerates yarn.lock.
+#   - Verification via `yarn npm audit` is best-effort only; `fixed` is based
+#     on `yarn up` succeeding. See OPEN QUESTIONS in the PR before relying on it.
+#
+# Runs in the target repo checkout. Writes `fixed=true|false` to $GITHUB_OUTPUT.
+#
+# Environment variables:
+#   YARN_PACKAGE  -- package name (required)
+#   YARN_VERSION  -- patched version to bump to (optional; latest if unset)
+
+set -euo pipefail
+
+: "${YARN_PACKAGE:?YARN_PACKAGE is required}"
+
+out() { echo "$1=$2" >> "${GITHUB_OUTPUT:-/dev/null}"; }
+
+if [ ! -f yarn.lock ]; then
+  echo "::warning ::No yarn.lock — not a yarn repo; skipping."
+  out fixed false
+  exit 0
+fi
+
+# Berry is delivered through corepack; enable it so the repo's pinned yarn
+# (packageManager in package.json / .yarnrc.yml) is the one that runs.
+corepack enable 2>/dev/null || true
+
+YARN_VER="$(yarn --version 2>/dev/null || echo 0)"
+echo "Detected yarn ${YARN_VER}"
+case "$YARN_VER" in
+  1.* | 0)
+    echo "::warning ::yarn classic (v1) is not supported yet (see #122); skipping."
+    out fixed false
+    exit 0
+    ;;
+esac
+
+echo "Before — where ${YARN_PACKAGE} resolves:"
+yarn why "$YARN_PACKAGE" 2>/dev/null || true
+
+# `-R` raises the dependency recursively (transitive deps included).
+TARGET="$YARN_PACKAGE"
+if [ -n "${YARN_VERSION:-}" ]; then
+  TARGET="${YARN_PACKAGE}@npm:^${YARN_VERSION}"
+fi
+echo "Running: yarn up -R ${TARGET}"
+if ! yarn up -R "$TARGET"; then
+  echo "::warning ::'yarn up -R ${TARGET}' failed; leaving for manual remediation."
+  out fixed false
+  exit 0
+fi
+
+# Best-effort verification. Format differs from npm audit and across Berry
+# minor versions, so this is informational only — do not gate on it yet (#122).
+echo "After — yarn npm audit (informational):"
+yarn npm audit --all --recursive 2>/dev/null | grep -i "$YARN_PACKAGE" || true
+
+echo "Upgraded ${YARN_PACKAGE} (verify via CI / Dependabot)."
+out fixed true

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -45,5 +45,16 @@ if git diff --quiet yarn.lock 2>/dev/null; then
   exit 0
 fi
 
-echo "yarn.lock updated for ${YARN_PACKAGE}."
+# Verify the advisory is actually gone (mirrors the npm path's post-fix audit).
+# `-R` only bumps within existing ranges, so a patch outside them leaves the
+# package still flagged — treat that as unfixed (needs a resolutions override).
+REMAINING=$(yarn npm audit --all --recursive --json 2>/dev/null \
+  | jq -rc --arg pkg "$YARN_PACKAGE" 'select(.value == $pkg)' 2>/dev/null | head -c1 || true)
+if [ -n "$REMAINING" ]; then
+  echo "::warning ::yarn npm audit still reports ${YARN_PACKAGE} after upgrade — needs a resolutions override (see #122)."
+  out fixed false
+  exit 0
+fi
+
+echo "yarn.lock updated and ${YARN_PACKAGE} clear in yarn npm audit."
 out fixed true

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -44,22 +44,29 @@ esac
 echo "Before — where ${YARN_PACKAGE} resolves:"
 yarn why "$YARN_PACKAGE" 2>/dev/null || true
 
-# `-R` raises the dependency recursively (transitive deps included).
-TARGET="$YARN_PACKAGE"
-if [ -n "${YARN_VERSION:-}" ]; then
-  TARGET="${YARN_PACKAGE}@npm:^${YARN_VERSION}"
-fi
-echo "Running: yarn up -R ${TARGET}"
-if ! yarn up -R "$TARGET"; then
-  echo "::warning ::'yarn up -R ${TARGET}' failed; leaving for manual remediation."
+# Berry v4's `-R` (recursive — covers transitive deps) takes the package NAME
+# only: it re-resolves every occurrence to the newest version satisfying each
+# existing range. Passing a version/range errors ("Ranges aren't allowed when
+# using --recursive"). --mode=update-lockfile writes yarn.lock without
+# installing, mirroring npm's --package-lock-only. Verified live against
+# mozilla/fxa (yarn@4.9.2): a single run bumped all vulnerable brace-expansion
+# lines to their patched in-range versions, yarn.lock-only.
+echo "Running: yarn up -R ${YARN_PACKAGE} --mode=update-lockfile"
+if ! yarn up -R "$YARN_PACKAGE" --mode=update-lockfile; then
+  echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; leaving for manual remediation."
   out fixed false
   exit 0
 fi
 
-# Best-effort verification. Format differs from npm audit and across Berry
-# minor versions, so this is informational only — do not gate on it yet (#122).
-echo "After — yarn npm audit (informational):"
-yarn npm audit --all --recursive 2>/dev/null | grep -i "$YARN_PACKAGE" || true
+# -R stays within the ranges declared by consumers. If the patched version is
+# outside every consumer's range (e.g. needs a major bump they don't allow),
+# yarn.lock won't change — that case needs a `resolutions` override, which is
+# not implemented yet (see #122).
+if git diff --quiet yarn.lock 2>/dev/null; then
+  echo "::warning ::yarn.lock unchanged — ${YARN_PACKAGE} likely needs a resolutions override to reach ${YARN_VERSION:-the patched version} (see #122)."
+  out fixed false
+  exit 0
+fi
 
-echo "Upgraded ${YARN_PACKAGE} (verify via CI / Dependabot)."
+echo "yarn.lock updated for ${YARN_PACKAGE} (advisory verified via CI / Dependabot)."
 out fixed true

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -377,8 +377,7 @@ class TestMainFlow:
         assert "npm_package=lodash" in outputs
         assert "npm_version=1.0.1" in outputs
 
-        # npm path defers to the workflow step; it never creates a PR here.
-        # (get_contents IS called now, to detect the package manager.)
+        # npm defers to the workflow step; no PR is created here.
         mock_repo.create_pull.assert_not_called()
 
     def test_yarn_bump_outputs_action(

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -16,6 +16,7 @@ from scripts.alert_report import (
 from scripts.post_alert_action import (
     create_advisory_and_fork,
     create_bump_pr,
+    detect_js_package_manager,
     detect_pip_lock_tool,
     dismiss_alert,
     fetch_patched_version,
@@ -376,9 +377,39 @@ class TestMainFlow:
         assert "npm_package=lodash" in outputs
         assert "npm_version=1.0.1" in outputs
 
-        # npm path should not touch repo contents or create PRs
-        mock_repo.get_contents.assert_not_called()
+        # npm path defers to the workflow step; it never creates a PR here.
+        # (get_contents IS called now, to detect the package manager.)
         mock_repo.create_pull.assert_not_called()
+
+    def test_yarn_bump_outputs_action(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """A yarn repo (yarn.lock, no package-lock.json) routes to yarn_bump."""
+        verdict_file(SAMPLE_VERDICT)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []  # no existing PR
+
+        def get_contents(path):
+            if path == "yarn.lock":
+                return MagicMock()
+            raise Exception("404")
+
+        mock_repo.get_contents.side_effect = get_contents
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            ALERT_ECOSYSTEM="npm", ALERT_PATCHED_VERSION="1.0.1",
+            GITHUB_OUTPUT=output_file,
+        )
+
+        outputs = open(output_file).read()
+        assert "action=yarn_bump" in outputs
+        assert "yarn_package=lodash" in outputs
+        assert "yarn_version=1.0.1" in outputs
 
     def test_dismiss_precedes_npm_bump_for_unaffected(
         self, verdict_file, tmp_path, monkeypatch
@@ -485,6 +516,33 @@ class TestDetectPipLockTool:
         else:
             assert result is not None
             assert result[0] == expected_tool
+
+
+class TestDetectJsPackageManager:
+    """detect_js_package_manager checks lockfiles: package-lock.json, yarn.lock, pnpm-lock.yaml."""
+
+    @pytest.mark.parametrize(
+        "files_present, expected",
+        [
+            ({"package-lock.json"}, "npm"),
+            ({"yarn.lock"}, "yarn"),
+            ({"pnpm-lock.yaml"}, "pnpm"),
+            ({"package-lock.json", "yarn.lock"}, "npm"),  # npm wins when both exist
+            (set(), None),
+        ],
+        ids=["npm", "yarn", "pnpm", "npm-wins", "none"],
+    )
+    def test_detection(self, files_present, expected):
+        repo = MagicMock()
+
+        def get_contents(path):
+            if path in files_present:
+                return MagicMock()
+            raise Exception("404")
+
+        repo.get_contents.side_effect = get_contents
+
+        assert detect_js_package_manager(repo) == expected
 
 
 class TestPipLockBumpFlow:


### PR DESCRIPTION
Addresses #122.

Adds a yarn remediation path so npm-only remediation stops skipping yarn repos (e.g. fxa). Routes by lockfile (`detect_js_package_manager`); a yarn repo runs `yarn up -R <pkg> --mode=update-lockfile` and opens a PR via the existing helpers, mirroring the npm/pip paths.

Validated live on fxa (yarn@4.9.2): one run cleared all transitive `brace-expansion` alerts, yarn.lock-only. See the PR comment for details.

Remaining (handoff): `resolutions` fallback when a patch is out of range, workspaces conflicts, classic v1, and end-to-end test of `yarn-bump.sh`.