### PR TITLE
fix(investigate): tag alert even when remediation fails; skip empty fork

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -380,9 +380,10 @@ jobs:
           ALERT_PACKAGE: ${{ inputs.alert_package }}
 
       # Mark this alert as investigated so the sweep does not re-trigger it.
-      # Uses a lightweight tag on the blender repo.
+      # Runs even if a remediation step failed (!cancelled), so a failed
+      # remediation can never cause the alert to be re-investigated every sweep.
       - name: Tag alert as investigated
-        if: inputs.dry_run != 'true'
+        if: ${{ !cancelled() && inputs.dry_run != 'true' }}
         run: |
           TAG_NAME="investigated/${TARGET_REPO}/${ALERT_NUMBER}"
           git tag "$TAG_NAME"

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -32,6 +32,7 @@ def render_markdown(
         "dismissed": "Alert dismissed",
         "noop": "No action taken",
         "private_fork": "Advisory created with private fork",
+        "advisory_only": "Advisory created (manual fix needed)",
         "existing_pr": "Existing Dependabot PR found",
         "bump_pr_created": "Bump PR created",
         "npm_bump": "npm bump PR created",
@@ -80,6 +81,7 @@ def annotation_line(
         "dismissed": "alert dismissed",
         "noop": "no action taken",
         "private_fork": "advisory created with private fork",
+        "advisory_only": "advisory created (manual fix needed)",
         "npm_bump": "npm bump PR created",
         "pip_lock_bump": "pip lock bump PR created",
     }

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -32,7 +32,7 @@ def render_markdown(
         "dismissed": "Alert dismissed",
         "noop": "No action taken",
         "private_fork": "Advisory created with private fork",
-        "advisory_only": "Advisory created (manual fix needed)",
+        "advisory_only": "No private fork - manual fix needed",
         "existing_pr": "Existing Dependabot PR found",
         "bump_pr_created": "Bump PR created",
         "npm_bump": "npm bump PR created",
@@ -81,7 +81,7 @@ def annotation_line(
         "dismissed": "alert dismissed",
         "noop": "no action taken",
         "private_fork": "advisory created with private fork",
-        "advisory_only": "advisory created (manual fix needed)",
+        "advisory_only": "no private fork - manual fix needed",
         "npm_bump": "npm bump PR created",
         "pip_lock_bump": "pip lock bump PR created",
     }

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -571,10 +571,14 @@ def main() -> None:
             dry_run,
             severity=severity.lower() if severity else "low",
         )
-        action = "private_fork"
+        if fork_repo:
+            action = "private_fork"
+            write_output("fork_repo", fork_repo)
+        else:
+            print("  No private fork available; advisory only, manual fix needed.")
+            action = "advisory_only"
         write_output("action", action)
         write_output("advisory_ghsa_id", ghsa_id)
-        write_output("fork_repo", fork_repo)
 
     write_step_summary(repo_name, alert_number, package_name, severity, action, verdict)
 

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -410,6 +410,54 @@ class TestMainFlow:
         assert "yarn_package=lodash" in outputs
         assert "yarn_version=1.0.1" in outputs
 
+    def test_affected_empty_fork_is_advisory_only(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Affected alert with no private fork -> advisory_only, not private_fork
+        (avoids the empty-clone failure that stalled remediation)."""
+        verdict_file({**SAMPLE_VERDICT, "affected": True, "recommended_action": "private_fork"})
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        with patch(
+            "scripts.post_alert_action.create_advisory_and_fork",
+            return_value=("GHSA-x", ""),
+        ):
+            self._run_main(
+                verdict_file, tmp_path, monkeypatch, mock_repo,
+                GITHUB_OUTPUT=output_file,
+            )
+
+        outputs = open(output_file).read()
+        assert "action=advisory_only" in outputs
+        assert "advisory_ghsa_id=GHSA-x" in outputs
+        assert "fork_repo=" not in outputs
+
+    def test_affected_with_fork_is_private_fork(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Affected alert with a fork still routes to private_fork."""
+        verdict_file({**SAMPLE_VERDICT, "affected": True, "recommended_action": "private_fork"})
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        with patch(
+            "scripts.post_alert_action.create_advisory_and_fork",
+            return_value=("GHSA-x", "owner/fork-abc"),
+        ):
+            self._run_main(
+                verdict_file, tmp_path, monkeypatch, mock_repo,
+                GITHUB_OUTPUT=output_file,
+            )
+
+        outputs = open(output_file).read()
+        assert "action=private_fork" in outputs
+        assert "fork_repo=owner/fork-abc" in outputs
+
     def test_dismiss_precedes_npm_bump_for_unaffected(
         self, verdict_file, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Fixes #129.

## The loop
The **Tag alert as investigated** step was the last step in the `remediate` job and ran only on success. So when a remediation step failed, the job aborted before tagging — the alert was never gated, and the sweep re-investigated it every cycle (re-billing Claude each time). We hit this live on mozilla/fxa: affected alerts failed cloning an empty private-fork URL and looped.

#119 only made the *yarn* step exit 0. The gate was still tied to remediation succeeding, so other paths (private-fork clone, etc.) still looped. This fixes the general case.

## Changes
- **Tag step runs with `!cancelled()`** — a failed remediation still tags the alert, so no remediation failure can cause a re-investigation loop.
- **`post_alert_action`:** when the advisory has no private fork, route to `advisory_only` instead of `private_fork`, so we never attempt an empty clone. (The failed run is still visible; it just no longer loops.)
- Tests for both affected-path routings (fork present → `private_fork`; no fork → `advisory_only`).

## Note
This makes the loop impossible for *any* remediation failure. Why the private fork comes back empty in the first place (advisory fork-creation/polling) is a separate correctness issue worth a follow-up — but it can no longer cause a loop.