### PR TITLE
feat(yarn): resolutions fallback for out-of-range transitive deps

### DIFF
--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -59,8 +59,9 @@ fi
 
 # Out-of-range patch: fall back to a resolutions pin, single-major trees only (#122).
 if [ "$state" = "flagged" ]; then
-  majors=$(grep -A1 "^\"${YARN_PACKAGE}@" yarn.lock 2>/dev/null \
-    | sed -nE 's/^ *version: "?([0-9]+).*/\1/p' | sort -u | grep -c .)
+  majors=$(yarn why "$YARN_PACKAGE" --json 2>/dev/null \
+    | jq -r '.children | keys[] | capture("@npm:(?<v>[0-9]+)").v' 2>/dev/null \
+    | sort -u | grep -c .)
   if [ -n "${YARN_VERSION:-}" ] && [ "$majors" = "1" ]; then
     echo "In-range bump insufficient; pinning ${YARN_PACKAGE} to ${YARN_VERSION} via resolutions."
     jq --arg p "$YARN_PACKAGE" --arg v "$YARN_VERSION" \

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -31,30 +31,49 @@ esac
 
 yarn why "$YARN_PACKAGE" 2>/dev/null || true
 
-# `-R` (recursive) takes the name only — a version or range is rejected.
+# Is the package still flagged by audit? (empty output = clear)
+audit_flagged() {
+  yarn npm audit --all --recursive --json 2>/dev/null \
+    | jq -rc --arg pkg "$1" 'select(.value == $pkg)' 2>/dev/null | head -c1 || true
+}
+
+# `-R` (recursive) takes the name only — a version/range is rejected. It bumps
+# every occurrence to the newest version each existing range allows.
 echo "Running: yarn up -R ${YARN_PACKAGE} --mode=update-lockfile"
-if ! yarn up -R "$YARN_PACKAGE" --mode=update-lockfile; then
-  echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; leaving for manual remediation."
+yarn up -R "$YARN_PACKAGE" --mode=update-lockfile \
+  || echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; trying a resolution."
+
+# If the in-range bump didn't clear the advisory, the patch is out of some
+# consumer's range. Fall back to a resolutions override — but only for a
+# single-major tree: a global resolution across majors would break the other
+# majors, and scoped resolutions can't be matched reliably (see #122).
+if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
+  majors=$(grep -A1 "^\"${YARN_PACKAGE}@" yarn.lock 2>/dev/null \
+    | sed -nE 's/^ *version: "?([0-9]+).*/\1/p' | sort -u | grep -c .)
+  if [ -n "${YARN_VERSION:-}" ] && [ "$majors" = "1" ]; then
+    echo "In-range bump insufficient; pinning ${YARN_PACKAGE} to ${YARN_VERSION} via resolutions."
+    jq --arg p "$YARN_PACKAGE" --arg v "$YARN_VERSION" \
+      '.resolutions = ((.resolutions // {}) + {($p): $v})' package.json > package.json.tmp \
+      && mv package.json.tmp package.json
+    yarn install --mode=update-lockfile || true
+  else
+    echo "::warning ::${YARN_PACKAGE} needs a resolution but has multiple major lines (or no patched version) — manual review needed (#122)."
+    out fixed false
+    exit 0
+  fi
+fi
+
+# Final check: advisory gone, and something actually changed to open a PR from.
+if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
+  echo "::warning ::${YARN_PACKAGE} still flagged after remediation — manual review needed (#122)."
+  out fixed false
+  exit 0
+fi
+if git diff --quiet yarn.lock package.json 2>/dev/null; then
+  echo "::warning ::no changes produced for ${YARN_PACKAGE}; nothing to open."
   out fixed false
   exit 0
 fi
 
-if git diff --quiet yarn.lock 2>/dev/null; then
-  echo "::warning ::yarn.lock unchanged — ${YARN_PACKAGE} likely needs a resolutions override to reach ${YARN_VERSION:-the patched version} (see #122)."
-  out fixed false
-  exit 0
-fi
-
-# Verify the advisory is actually gone (mirrors the npm path's post-fix audit).
-# `-R` only bumps within existing ranges, so a patch outside them leaves the
-# package still flagged — treat that as unfixed (needs a resolutions override).
-REMAINING=$(yarn npm audit --all --recursive --json 2>/dev/null \
-  | jq -rc --arg pkg "$YARN_PACKAGE" 'select(.value == $pkg)' 2>/dev/null | head -c1 || true)
-if [ -n "$REMAINING" ]; then
-  echo "::warning ::yarn npm audit still reports ${YARN_PACKAGE} after upgrade — needs a resolutions override (see #122)."
-  out fixed false
-  exit 0
-fi
-
-echo "yarn.lock updated and ${YARN_PACKAGE} clear in yarn npm audit."
+echo "${YARN_PACKAGE} cleared in yarn npm audit."
 out fixed true

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -31,23 +31,34 @@ esac
 
 yarn why "$YARN_PACKAGE" 2>/dev/null || true
 
-# Is the package still flagged by audit? (empty output = clear)
-audit_flagged() {
-  yarn npm audit --all --recursive --json 2>/dev/null \
-    | jq -rc --arg pkg "$1" 'select(.value == $pkg)' 2>/dev/null | head -c1 || true
+# Package audit state: clean | flagged | error (error = audit run failed).
+pkg_audit_state() {
+  local pkg="$1" out rc
+  out=$(yarn npm audit --all --recursive --json 2>/dev/null)
+  rc=$?
+  if [ "$rc" -eq 0 ]; then echo clean; return; fi
+  if [ -z "$out" ]; then echo error; return; fi
+  if printf '%s\n' "$out" | jq -e --arg p "$pkg" 'select(.value == $p)' >/dev/null 2>&1; then
+    echo flagged
+  else
+    echo clean
+  fi
 }
 
-# `-R` (recursive) takes the name only — a version/range is rejected. It bumps
-# every occurrence to the newest version each existing range allows.
+# -R takes the package name only (a version/range is rejected).
 echo "Running: yarn up -R ${YARN_PACKAGE} --mode=update-lockfile"
 yarn up -R "$YARN_PACKAGE" --mode=update-lockfile \
   || echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; trying a resolution."
 
-# If the in-range bump didn't clear the advisory, the patch is out of some
-# consumer's range. Fall back to a resolutions override — but only for a
-# single-major tree: a global resolution across majors would break the other
-# majors, and scoped resolutions can't be matched reliably (see #122).
-if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
+state=$(pkg_audit_state "$YARN_PACKAGE")
+if [ "$state" = "error" ]; then
+  echo "::warning ::yarn npm audit failed to run — cannot verify ${YARN_PACKAGE}; treating as unremediated."
+  out fixed false
+  exit 0
+fi
+
+# Out-of-range patch: fall back to a resolutions pin, single-major trees only (#122).
+if [ "$state" = "flagged" ]; then
   majors=$(grep -A1 "^\"${YARN_PACKAGE}@" yarn.lock 2>/dev/null \
     | sed -nE 's/^ *version: "?([0-9]+).*/\1/p' | sort -u | grep -c .)
   if [ -n "${YARN_VERSION:-}" ] && [ "$majors" = "1" ]; then
@@ -55,7 +66,11 @@ if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
     jq --arg p "$YARN_PACKAGE" --arg v "$YARN_VERSION" \
       '.resolutions = ((.resolutions // {}) + {($p): $v})' package.json > package.json.tmp \
       && mv package.json.tmp package.json
-    yarn install --mode=update-lockfile || true
+    if ! yarn install --mode=update-lockfile; then
+      echo "::warning ::yarn install failed after pinning ${YARN_PACKAGE} — treating as unremediated."
+      out fixed false
+      exit 0
+    fi
   else
     echo "::warning ::${YARN_PACKAGE} needs a resolution but has multiple major lines (or no patched version) — manual review needed (#122)."
     out fixed false
@@ -63,9 +78,8 @@ if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
   fi
 fi
 
-# Final check: advisory gone, and something actually changed to open a PR from.
-if [ -n "$(audit_flagged "$YARN_PACKAGE")" ]; then
-  echo "::warning ::${YARN_PACKAGE} still flagged after remediation — manual review needed (#122)."
+if [ "$(pkg_audit_state "$YARN_PACKAGE")" != "clean" ]; then
+  echo "::warning ::${YARN_PACKAGE} not verified clear after remediation — manual review needed (#122)."
   out fixed false
   exit 0
 fi


### PR DESCRIPTION
Addresses the remaining scope of #122 (the yarn *core* path landed in #123).

## What
When `yarn up -R <pkg>` can't reach the patched version — because a consumer's declared range blocks it — fall back to a `resolutions` override that pins the package to the patched version, then re-audit.

Per the discussion, resolutions are used **only when mandatory** (the in-range bump left the alert flagged), not by default.

## Why it's gated to single-major trees
Validated live on mozilla/fxa (yarn@4.9.2):
- **Single-major** (e.g. undici, only 7.x in the tree): a global `resolutions: {undici: 7.29.0}` cleared every undici advisory with a green install. ✅
- **Multi-major** (brace-expansion has 1.x / 2.x / 5.x, each with its own patched version): a single global resolution would force all lines to one version and break the others. Berry's *scoped* resolutions (`pkg@range`) don't help — they must match each consumer's exact descriptor range, so an automated guess silently no-ops (confirmed on fxa).

So: apply a global resolution when the tree has one major line; otherwise **flag for manual review** rather than force-break. That covers the common case safely and refuses the unsafe one.

## Notes
- `yarn-bump.sh` already commits `package.json`, so the resolutions entry ships in the PR for review.
- Multi-major packages are exactly what the *group-by-package* work (separate issue) should handle — bumping all of a package's lines together, which `yarn up -R` already does correctly in-range.