### PR TITLE
fix(dismiss): truncate dismissed_comment to GitHub's 280-char limit

### DIFF
--- a/prompts/investigate-alert-prompt.md
+++ b/prompts/investigate-alert-prompt.md
@@ -61,7 +61,7 @@ labeled `VERDICT_JSON`. Do not write any files. Just output this block:
 {
   "affected": false,
   "confidence": "high",
-  "reason": "Brief explanation of why the repo is or is not affected",
+  "reason": "Concise reason (<=271 chars); prefixed into the dismissal comment",
   "vulnerable_paths": [],
   "recommended_action": "bump_pr"
 }
@@ -71,7 +71,7 @@ labeled `VERDICT_JSON`. Do not write any files. Just output this block:
 **Fields:**
 - `affected`: true if the vulnerability impacts this repo's code
 - `confidence`: "high", "medium", or "low"
-- `reason`: one-paragraph explanation
+- `reason`: concise explanation, **≤271 characters** — leaves room for the "BLEnder: " prefix under GitHub's 280-char dismissal-comment cap
 - `vulnerable_paths`: list of `file:line` strings where vulnerable code is called (empty if not affected)
 - `recommended_action`: one of:
   - `"existing_pr"` — a Dependabot PR already bumps this package

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -433,10 +433,14 @@ def dismiss_alert(
         return
 
     url = f"/repos/{repo.full_name}/dependabot/alerts/{alert_number}"
+    # GitHub caps dismissed_comment at 280 chars; truncate to avoid a 422.
+    comment = f"{BLENDER_NAME}: {reason}"
+    if len(comment) > 280:
+        comment = comment[:277] + "..."
     payload = {
         "state": "dismissed",
         "dismissed_reason": "not_used",
-        "dismissed_comment": f"{BLENDER_NAME}: {reason}",
+        "dismissed_comment": comment,
     }
     repo._requester.requestJsonAndCheck("PATCH", url, input=payload)
     print(f"  Dismissed alert #{alert_number}")

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -102,6 +102,16 @@ class TestDismissAlert:
         dismiss_alert(repo, 42, "not used", dry_run=True)
         repo._requester.requestJsonAndCheck.assert_not_called()
 
+    def test_truncates_long_comment(self):
+        """GitHub caps dismissed_comment at 280 chars; a long reason must not 422."""
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        dismiss_alert(repo, 42, "x" * 500, dry_run=False)
+        args, kwargs = repo._requester.requestJsonAndCheck.call_args
+        comment = kwargs["input"]["dismissed_comment"]
+        assert len(comment) <= 280
+        assert comment.endswith("...")
+
 
 class TestRenderMarkdown:
     def test_contains_key_elements(self):


### PR DESCRIPTION
Fixes #134.

`dismiss_alert` sent `BLEnder: <full verdict reason>` (~1.1k chars) as the Dependabot alert's `dismissed_comment`, which GitHub rejects with 422 (max 280). Result: **every** not-affected low/medium dismissal failed, so no alert was ever auto-dismissed (confirmed live on mozilla/fxa — 194 open, 0 BLEnder dismissals).

Truncate to 280 (277 + '…'). Added a regression test.

Verified the root cause in a live run for fxa alert #830 (body-parser, low): `affected=False` → tried to dismiss → 422 on the 1158-char comment.