### PR TITLE
fix(sweep): paginate the Dependabot alerts fetch

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -21,6 +21,9 @@ investigate:
   max_budget_usd: 1.50
   severity_threshold: ""
   dismiss_unaffected: false
+  # Max investigations dispatched per repo per sweep (paces cost/concurrency;
+  # the rest are picked up on later sweeps). 0 = unlimited.
+  max_per_sweep: 50
 
 auto_engineer:
   enabled: false

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -21,8 +21,7 @@ investigate:
   max_budget_usd: 1.50
   severity_threshold: ""
   dismiss_unaffected: false
-  # Max investigations dispatched per repo per sweep (paces cost/concurrency;
-  # the rest are picked up on later sweeps). 0 = unlimited.
+  # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50
 
 auto_engineer:

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -712,9 +712,18 @@ def sweep(app_id: str, private_key: str) -> list[Action]:
     return actions
 
 
-# Global safety backstop: max investigations dispatched in one sweep run
-# (across all repos), on top of the per-repo investigate.max_per_sweep.
+# Global backstop: max investigations dispatched per sweep run (all repos).
 INVESTIGATE_TOTAL_CAP = 200
+
+
+def cap_investigations(actions: list[Action], cap: int) -> list[Action]:
+    """Cap investigate actions to `cap`, preserving all other actions."""
+    inv = [a for a in actions if a.action == "investigate"]
+    if len(inv) <= cap:
+        return actions
+    other = [a for a in actions if a.action != "investigate"]
+    print(f"Global cap: investigations {len(inv)} -> {cap}")
+    return other + inv[:cap]
 
 
 def main() -> None:
@@ -730,12 +739,7 @@ def main() -> None:
         sys.exit(1)
 
     actions = sweep(app_id, private_key)
-
-    inv = [a for a in actions if a.action == "investigate"]
-    if len(inv) > INVESTIGATE_TOTAL_CAP:
-        other = [a for a in actions if a.action != "investigate"]
-        print(f"Global cap: investigations {len(inv)} -> {INVESTIGATE_TOTAL_CAP}")
-        actions = other + inv[:INVESTIGATE_TOTAL_CAP]
+    actions = cap_investigations(actions, INVESTIGATE_TOTAL_CAP)
 
     print(f"\n=== Sweep complete: {len(actions)} action(s) ===")
     output = [a.to_dict() for a in actions]

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -592,13 +592,24 @@ def check_alerts(
     min_rank = SEVERITY_RANK.get(threshold, 0)
 
     url = f"/repos/{repo.full_name}/dependabot/alerts"
-    try:
-        headers, data = repo._requester.requestJsonAndCheck(
-            "GET", url, parameters={"state": "open", "per_page": "100"}
-        )
-    except Exception as e:
-        print(f"    Could not fetch alerts: {e}")
-        return actions
+    data: list = []
+    page = 1
+    while True:
+        try:
+            _, page_data = repo._requester.requestJsonAndCheck(
+                "GET",
+                url,
+                parameters={"state": "open", "per_page": "100", "page": str(page)},
+            )
+        except Exception as e:
+            print(f"    Could not fetch alerts (page {page}): {e}")
+            break
+        if not page_data:
+            break
+        data.extend(page_data)
+        if len(page_data) < 100:
+            break
+        page += 1
 
     if not data:
         print("    No open Dependabot alerts")

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -590,6 +590,7 @@ def check_alerts(
         return actions
     threshold = str(inv_config.get("severity_threshold", "") or "").lower()
     min_rank = SEVERITY_RANK.get(threshold, 0)
+    max_per_sweep = int(inv_config.get("max_per_sweep", 0) or 0)
 
     url = f"/repos/{repo.full_name}/dependabot/alerts"
     data: list = []
@@ -671,6 +672,12 @@ def check_alerts(
             )
         )
 
+    if max_per_sweep and len(actions) > max_per_sweep:
+        print(
+            f"    Capping investigations {len(actions)} -> {max_per_sweep} "
+            "(investigate.max_per_sweep)"
+        )
+        actions = actions[:max_per_sweep]
     return actions
 
 
@@ -705,6 +712,11 @@ def sweep(app_id: str, private_key: str) -> list[Action]:
     return actions
 
 
+# Global safety backstop: max investigations dispatched in one sweep run
+# (across all repos), on top of the per-repo investigate.max_per_sweep.
+INVESTIGATE_TOTAL_CAP = 200
+
+
 def main() -> None:
     app_id = os.environ.get("BLENDER_APP_ID", "")
     private_key = os.environ.get("BLENDER_APP_PRIVATE_KEY", "")
@@ -718,6 +730,12 @@ def main() -> None:
         sys.exit(1)
 
     actions = sweep(app_id, private_key)
+
+    inv = [a for a in actions if a.action == "investigate"]
+    if len(inv) > INVESTIGATE_TOTAL_CAP:
+        other = [a for a in actions if a.action != "investigate"]
+        print(f"Global cap: investigations {len(inv)} -> {INVESTIGATE_TOTAL_CAP}")
+        actions = other + inv[:INVESTIGATE_TOTAL_CAP]
 
     print(f"\n=== Sweep complete: {len(actions)} action(s) ===")
     output = [a.to_dict() for a in actions]

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -433,6 +433,17 @@ class TestAlertDiscovery:
         assert len(investigates) == 105
         assert repo._requester.requestJsonAndCheck.call_count == 2
 
+    def test_max_per_sweep_caps_investigations(self):
+        """Per-repo max_per_sweep limits how many investigations are emitted."""
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        page = [_make_alert(n, f"pkg{n}") for n in range(1, 61)]  # 60 alerts
+        repo._requester.requestJsonAndCheck.side_effect = [({}, page)]
+        repo.get_branches.return_value = []
+
+        actions = check_alerts(repo, config={"investigate": {"max_per_sweep": 50}})
+        assert len([a for a in actions if a.action == "investigate"]) == 50
+
     def test_investigate_disabled_skips_alerts(self):
         """investigate.enabled=false -> no alerts fetched or emitted."""
         repo = MagicMock()

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -432,6 +432,12 @@ class TestAlertDiscovery:
         investigates = [a for a in actions if a.action == "investigate"]
         assert len(investigates) == 105
         assert repo._requester.requestJsonAndCheck.call_count == 2
+        # Verify it advanced pages (not fetching page 1 twice)
+        pages = [
+            c.kwargs["parameters"]["page"]
+            for c in repo._requester.requestJsonAndCheck.call_args_list
+        ]
+        assert pages == ["1", "2"]
 
     def test_max_per_sweep_caps_investigations(self):
         """Per-repo max_per_sweep limits how many investigations are emitted."""

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -419,6 +419,20 @@ class TestAlertDiscovery:
         assert actions[0].alert_number == 42
         assert actions[0].alert_package == "lodash"
 
+    def test_alert_discovery_paginates_beyond_100(self):
+        """Fetches every page, not just the first 100 (repos with >100 alerts)."""
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        page1 = [_make_alert(n, f"pkg{n}") for n in range(1, 101)]  # 100
+        page2 = [_make_alert(n, f"pkg{n}") for n in range(101, 106)]  # 5
+        repo._requester.requestJsonAndCheck.side_effect = [({}, page1), ({}, page2)]
+        repo.get_branches.return_value = []
+
+        actions = check_alerts(repo)
+        investigates = [a for a in actions if a.action == "investigate"]
+        assert len(investigates) == 105
+        assert repo._requester.requestJsonAndCheck.call_count == 2
+
     def test_investigate_disabled_skips_alerts(self):
         """investigate.enabled=false -> no alerts fetched or emitted."""
         repo = MagicMock()

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -11,6 +11,7 @@ from tests.scripts import make_branch, make_comment, make_commit, make_review, m
 
 from scripts.sweep import (
     ALLOWED_OWNERS,
+    cap_investigations,
     check_alerts,
     fetch_investigated_alerts,
     process_repo,
@@ -647,3 +648,24 @@ class TestOwnerAllowlist:
 
         mock_process.assert_not_called()
         assert actions == []
+
+
+class TestCapInvestigations:
+    def _inv(self, n):
+        return [MagicMock(action="investigate") for _ in range(n)]
+
+    def test_over_cap_keeps_cap_and_preserves_others(self):
+        others = [MagicMock(action="automerge"), MagicMock(action="fix")]
+        result = cap_investigations(self._inv(250) + others, 200)
+        assert sum(1 for a in result if a.action == "investigate") == 200
+        assert sum(1 for a in result if a.action != "investigate") == 2
+
+    def test_exact_boundary_unchanged(self):
+        actions = self._inv(200)
+        result = cap_investigations(actions, 200)
+        assert len(result) == 200
+        assert all(a.action == "investigate" for a in result)
+
+    def test_under_cap_returns_unchanged(self):
+        actions = self._inv(10) + [MagicMock(action="fix")]
+        assert cap_investigations(actions, 200) is actions


### PR DESCRIPTION
Fixes #136.

`check_alerts` requested `per_page=100` and used only the first page, so repos with >100 open alerts (mozilla/fxa has 194) had the rest never investigated — confirmed live: 100 of 194 investigated, 94 invisible.

Paginate until a page returns <100. Added a >100-alert regression test.