### PR TITLE
fix(sweep): cursor pagination for Dependabot alerts (hotfix for #137)

### DIFF
--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -28,6 +28,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from urllib.parse import unquote
 
 from github import Auth, GithubIntegration
 from github.GithubException import UnknownObjectException
@@ -594,23 +595,38 @@ def check_alerts(
 
     url = f"/repos/{repo.full_name}/dependabot/alerts"
     data: list = []
-    page = 1
-    while True:
+    params = {"state": "open", "per_page": "100"}
+    seen_cursors: set = set()
+    # range() is a backstop; the seen-cursor check below stops a repeating (runaway) cursor
+    for _ in range(100):
         try:
-            _, page_data = repo._requester.requestJsonAndCheck(
-                "GET",
-                url,
-                parameters={"state": "open", "per_page": "100", "page": str(page)},
+            headers, page_data = repo._requester.requestJsonAndCheck(
+                "GET", url, parameters=params
             )
         except Exception as e:
-            print(f"    Could not fetch alerts (page {page}): {e}")
+            print(f"    Could not fetch alerts: {e}")
             break
         if not page_data:
             break
         data.extend(page_data)
-        if len(page_data) < 100:
+        # Dependabot alerts use cursor pagination — follow Link rel="next" after= (page param is unsupported)
+        nxt = re.search(r'<([^>]+)>;\s*rel="next"', headers.get("link", "") or "")
+        after = re.search(r"[?&]after=([^&]+)", nxt.group(1)) if nxt else None
+        if not after:
             break
-        page += 1
+        # unquote: the Link cursor is URL-encoded; PyGithub re-encodes params, so pass it decoded
+        cursor = unquote(after.group(1))
+        if cursor in seen_cursors:  # repeated cursor = runaway; stop before re-fetching
+            break
+        seen_cursors.add(cursor)
+        params = {"state": "open", "per_page": "100", "after": cursor}
+    else:
+        print(
+            f"    Warning: pagination hit page cap for {repo.full_name} — results may be truncated"
+        )
+
+    # Dedupe by alert number in case a misbehaving cursor re-served a page
+    data = list({a.get("number"): a for a in data}.values())
 
     if not data:
         print("    No open Dependabot alerts")

--- a/tests/scripts/test_sweep.py
+++ b/tests/scripts/test_sweep.py
@@ -426,19 +426,35 @@ class TestAlertDiscovery:
         repo.full_name = "owner/repo"
         page1 = [_make_alert(n, f"pkg{n}") for n in range(1, 101)]  # 100
         page2 = [_make_alert(n, f"pkg{n}") for n in range(101, 106)]  # 5
-        repo._requester.requestJsonAndCheck.side_effect = [({}, page1), ({}, page2)]
+        # First response carries a URL-encoded cursor in the Link header; second has none.
+        link = '<https://api.github.com/x/dependabot/alerts?after=A%2Bb%3D%3D&per_page=100>; rel="next"'
+        repo._requester.requestJsonAndCheck.side_effect = [({"link": link}, page1), ({}, page2)]
         repo.get_branches.return_value = []
 
         actions = check_alerts(repo)
         investigates = [a for a in actions if a.action == "investigate"]
         assert len(investigates) == 105
         assert repo._requester.requestJsonAndCheck.call_count == 2
-        # Verify it advanced pages (not fetching page 1 twice)
-        pages = [
-            c.kwargs["parameters"]["page"]
-            for c in repo._requester.requestJsonAndCheck.call_args_list
-        ]
-        assert pages == ["1", "2"]
+        # Second request carries the cursor DECODED (PyGithub re-encodes params — no double-encoding)
+        second = repo._requester.requestJsonAndCheck.call_args_list[1].kwargs["parameters"]
+        assert second.get("after") == "A+b=="
+
+    def test_alert_discovery_bounds_runaway_pagination(self):
+        """A repeating cursor stops as soon as it recurs and emits no duplicate actions."""
+        repo = MagicMock()
+        repo.full_name = "owner/repo"
+        link = '<https://api.github.com/x/dependabot/alerts?after=STUCK&per_page=100>; rel="next"'
+        # Server keeps returning the same page + the same next cursor forever.
+        repo._requester.requestJsonAndCheck.return_value = (
+            {"link": link},
+            [_make_alert(1, "pkg")],
+        )
+        repo.get_branches.return_value = []
+
+        actions = check_alerts(repo)
+        # Stops once STUCK recurs (not 100 fetches) and dedupes to a single action.
+        assert repo._requester.requestJsonAndCheck.call_count == 2
+        assert len([a for a in actions if a.action == "investigate"]) == 1
 
     def test_max_per_sweep_caps_investigations(self):
         """Per-repo max_per_sweep limits how many investigations are emitted."""


### PR DESCRIPTION
**Regression from #137 — alert fetching is broken for all repos right now.**

#137 added `?page=N` pagination, but the Dependabot alerts API doesn't support page-based paging:
```
Could not fetch alerts (page 1): Pagination using the `page` parameter is not supported.: 400
```
So every fetch fails on page 1 → `No open Dependabot alerts` → **0 investigations dispatched (every repo)**. Seen live in the latest sweeps for mozilla/fxa (0 of 194).

Fix: use the API's **cursor** pagination — follow the `after` cursor from the Link header's `rel="next"`. Verified the parser against realistic Link headers (cursor-not-last, prev-only last page, empty). Per-sweep/global caps unchanged. Test rewritten for cursor semantics.