### PR TITLE
feat(investigate): dismiss high-severity not-affected alerts, confidence-gated

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -76,6 +76,12 @@ outputs:
   dismiss_unaffected:
     description: 'Whether to dismiss unaffected alerts'
     value: ${{ steps.config.outputs.dismiss_unaffected }}
+  dismiss_high:
+    description: 'Whether to dismiss high-severity unaffected alerts'
+    value: ${{ steps.config.outputs.dismiss_high }}
+  dismiss_min_confidence:
+    description: 'Minimum verdict confidence required to dismiss high-severity'
+    value: ${{ steps.config.outputs.dismiss_min_confidence }}
   install_failed:
     description: 'Whether the target dependency install failed'
     value: ${{ steps.install-deps.outcome == 'failure' && 'true' || 'false' }}
@@ -128,6 +134,8 @@ runs:
           echo "install_command=$(yq '.install_command // ""' "$CONFIG_FILE")"
           echo "repo_name=$(yq '.repo_name // ""' "$CONFIG_FILE")"
           echo "dismiss_unaffected=$(yq '.investigate.dismiss_unaffected // "false"' "$CONFIG_FILE")"
+          echo "dismiss_high=$(yq '.investigate.dismiss_high // "false"' "$CONFIG_FILE")"
+          echo "dismiss_min_confidence=$(yq '.investigate.dismiss_min_confidence // "high"' "$CONFIG_FILE")"
         } >> "$GITHUB_OUTPUT"
       env:
         CHECKOUT_PATH: ${{ inputs.checkout-path }}

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -181,6 +181,8 @@ jobs:
           ALERT_PATCHED_VERSION: ${{ inputs.alert_patched_version }}
           DRY_RUN: ${{ inputs.dry_run }}
           DISMISS_UNAFFECTED: ${{ steps.setup.outputs.dismiss_unaffected }}
+          DISMISS_HIGH: ${{ steps.setup.outputs.dismiss_high }}
+          DISMISS_MIN_CONFIDENCE: ${{ steps.setup.outputs.dismiss_min_confidence }}
 
       # --- npm transitive dependency bump (lock file only) ---
       - name: Run npm audit fix

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -21,6 +21,10 @@ investigate:
   max_budget_usd: 1.50
   severity_threshold: ""
   dismiss_unaffected: false
+  # Also auto-dismiss high-severity not-affected alerts (critical is never dismissed)
+  dismiss_high: false
+  # Minimum verdict confidence to auto-dismiss high: low | medium | high
+  dismiss_min_confidence: high
   # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50
 

--- a/prompts/investigate-alert-prompt.md
+++ b/prompts/investigate-alert-prompt.md
@@ -78,7 +78,7 @@ labeled `VERDICT_JSON`. Do not write any files. Just output this block:
   - `"bump_pr"` — not affected, but open a PR to bump the dependency
   - `"private_fork"` — affected, needs a fix in a private security fork
 
-**Confidence levels:**
+**Confidence levels:** (a `high`-severity not-affected verdict may be auto-dismissed only when confidence is `high`, so reserve it for genuine certainty)
 - `high`: clear evidence the package is or is not used in vulnerable ways
 - `medium`: package is used but the vulnerable code path is ambiguous
 - `low`: cannot determine with confidence

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -41,8 +41,10 @@ from github import Auth, Github  # noqa: E402
 from scripts.alert_report import write_step_summary  # noqa: E402
 
 BLENDER_NAME = "BLEnder"
-DISMISS_BLOCKED_SEVERITIES = {"critical", "high"}
+# Severities BLEnder never auto-dismisses, even when confident it's not affected
+NEVER_DISMISS_SEVERITIES = {"critical"}
 DISMISS_UNKNOWN_SEVERITIES = {"", "unknown"}
+CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
 VERDICT_FILE = ".blender-alert-verdict.json"
 REQUIRED_KEYS = {
     "affected",
@@ -51,6 +53,31 @@ REQUIRED_KEYS = {
     "vulnerable_paths",
     "recommended_action",
 }
+
+
+def dismiss_allowed(
+    enabled: bool,
+    severity: str,
+    confidence: str,
+    allow_high: bool,
+    min_confidence: str,
+) -> bool:
+    """Whether a not-affected alert may be auto-dismissed.
+
+    Critical is never auto-dismissed. High requires allow_high and a verdict
+    confidence at or above min_confidence. Low/medium dismiss whenever enabled.
+    """
+    if not enabled or severity in DISMISS_UNKNOWN_SEVERITIES:
+        return False
+    if severity in NEVER_DISMISS_SEVERITIES:
+        return False
+    if severity == "high":
+        if not allow_high:
+            return False
+        actual = CONFIDENCE_RANK.get(confidence, 0)
+        required = CONFIDENCE_RANK.get(min_confidence, 3)
+        return actual >= required
+    return True
 
 
 def load_verdict() -> dict | None:
@@ -460,6 +487,12 @@ def main() -> None:
         "1",
         "yes",
     )
+    dismiss_high = os.environ.get("DISMISS_HIGH", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    dismiss_min_confidence = os.environ.get("DISMISS_MIN_CONFIDENCE", "high").lower()
 
     if not token or not repo_name:
         print("Error: GH_TOKEN and REPO are required.")
@@ -492,17 +525,23 @@ def main() -> None:
     if not affected:
         # Check for an existing PR (Dependabot or BLEnder) that bumps this package
         existing_pr = find_existing_bump_pr(repo, package_name)
+        severity_l = severity.lower()
+        confidence = str(verdict.get("confidence", "")).lower()
 
         if existing_pr:
             print(f"  Existing PR #{existing_pr} covers this package.")
             comment_on_pr(repo, existing_pr, reason, dry_run)
             action = "existing_pr"
-        elif (
-            dismiss_enabled
-            and severity.lower() not in DISMISS_BLOCKED_SEVERITIES
-            and severity.lower() not in DISMISS_UNKNOWN_SEVERITIES
+        elif dismiss_allowed(
+            dismiss_enabled,
+            severity_l,
+            confidence,
+            dismiss_high,
+            dismiss_min_confidence,
         ):
-            print("  Unaffected + dismiss enabled (low/medium). Dismissing alert.")
+            print(
+                f"  Unaffected + dismiss allowed ({severity_l}, confidence={confidence}). Dismissing alert."
+            )
             dismiss_alert(repo, alert_number, reason, dry_run)
             action = "dismissed"
         elif recommended == "bump_pr":

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -343,6 +343,61 @@ class TestMainFlow:
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
 
+    def test_dismiss_high_when_enabled_and_confident(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """High is dismissed when dismiss_high is on and confidence meets the bar."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", DISMISS_HIGH="true", ALERT_SEVERITY="high",
+        )
+
+        args = mock_repo._requester.requestJsonAndCheck.call_args
+        assert args.args[0] == "PATCH"
+        assert args.kwargs["input"]["state"] == "dismissed"
+
+    def test_dismiss_high_blocked_below_confidence(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """High is NOT dismissed when confidence is below the configured bar."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", DISMISS_HIGH="true",
+            DISMISS_MIN_CONFIDENCE="high", ALERT_SEVERITY="high",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_dismiss_never_critical(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Critical is never auto-dismissed, even at high confidence with a low bar."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", DISMISS_HIGH="true",
+            DISMISS_MIN_CONFIDENCE="low", ALERT_SEVERITY="critical",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
     def test_dismiss_skips_unknown_severity(
         self, verdict_file, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What

Opt-in config to let BLEnder auto-dismiss **high**-severity *not-affected* alerts when its verdict confidence meets a configurable bar. Critical is never auto-dismissed; low/medium behavior is unchanged.

```yaml
investigate:
  dismiss_high: false          # opt-in (default off)
  dismiss_min_confidence: high # low | medium | high
```

## Why

Not-affected high-severity findings previously fell through to a noop and stayed open — 103 such alerts on fxa. The verdict (with confidence) was computed but nothing acted on it.

## How

- Policy centralized in `dismiss_allowed()` (critical excluded; high requires `dismiss_high` + confidence ≥ bar).
- Wired through `setup-target` outputs → investigate workflow env.
- Prompt reserves `confidence: high` for genuine certainty since it now gates dismissal.
- Tests: high dismissed when confident, blocked below bar, never for critical.

## Rollout

Ships **default-off**. To measure impact safely before enabling repo-wide, enable on fxa and clear the high-alert tags for one re-investigation pass.