### PR TITLE
feat(investigate): require a minimum confidence to auto-dismiss alerts

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -76,6 +76,9 @@ outputs:
   dismiss_unaffected:
     description: 'Whether to dismiss unaffected alerts'
     value: ${{ steps.config.outputs.dismiss_unaffected }}
+  dismiss_min_confidence:
+    description: 'Minimum verdict confidence required to auto-dismiss'
+    value: ${{ steps.config.outputs.dismiss_min_confidence }}
   install_failed:
     description: 'Whether the target dependency install failed'
     value: ${{ steps.install-deps.outcome == 'failure' && 'true' || 'false' }}
@@ -128,6 +131,7 @@ runs:
           echo "install_command=$(yq '.install_command // ""' "$CONFIG_FILE")"
           echo "repo_name=$(yq '.repo_name // ""' "$CONFIG_FILE")"
           echo "dismiss_unaffected=$(yq '.investigate.dismiss_unaffected // "false"' "$CONFIG_FILE")"
+          echo "dismiss_min_confidence=$(yq '.investigate.dismiss_min_confidence // "high"' "$CONFIG_FILE")"
         } >> "$GITHUB_OUTPUT"
       env:
         CHECKOUT_PATH: ${{ inputs.checkout-path }}

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -181,6 +181,7 @@ jobs:
           ALERT_PATCHED_VERSION: ${{ inputs.alert_patched_version }}
           DRY_RUN: ${{ inputs.dry_run }}
           DISMISS_UNAFFECTED: ${{ steps.setup.outputs.dismiss_unaffected }}
+          DISMISS_MIN_CONFIDENCE: ${{ steps.setup.outputs.dismiss_min_confidence }}
 
       # --- npm transitive dependency bump (lock file only) ---
       - name: Run npm audit fix

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -21,7 +21,9 @@ investigate:
   max_budget_usd: 1.50
   severity_threshold: ""
   dismiss_unaffected: false
-  # Minimum verdict confidence required to auto-dismiss (any severity): low | medium | high
+  # Minimum verdict confidence required to auto-dismiss: low | medium | high
+  # (a confidence floor for every dismissal; which severities are dismissable is
+  # separate — high/critical are not auto-dismissed regardless of this value)
   dismiss_min_confidence: high
   # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -21,6 +21,8 @@ investigate:
   max_budget_usd: 1.50
   severity_threshold: ""
   dismiss_unaffected: false
+  # Minimum verdict confidence required to auto-dismiss (any severity): low | medium | high
+  dismiss_min_confidence: high
   # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50
 

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -23,7 +23,7 @@ investigate:
   dismiss_unaffected: false
   # Minimum verdict confidence required to auto-dismiss: low | medium | high
   # (a confidence floor for every dismissal; which severities are dismissable is
-  # separate — high/critical are not auto-dismissed regardless of this value)
+  # separate)
   dismiss_min_confidence: high
   # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50

--- a/prompts/investigate-alert-prompt.md
+++ b/prompts/investigate-alert-prompt.md
@@ -78,7 +78,7 @@ labeled `VERDICT_JSON`. Do not write any files. Just output this block:
   - `"bump_pr"` — not affected, but open a PR to bump the dependency
   - `"private_fork"` — affected, needs a fix in a private security fork
 
-**Confidence levels:**
+**Confidence levels:** (a not-affected verdict is auto-dismissed only when confidence meets the repo's bar, so reserve `high` for genuine certainty)
 - `high`: clear evidence the package is or is not used in vulnerable ways
 - `medium`: package is used but the vulnerable code path is ambiguous
 - `low`: cannot determine with confidence

--- a/scripts/alert_report.py
+++ b/scripts/alert_report.py
@@ -13,6 +13,7 @@ def render_markdown(
     severity: str,
     action: str,
     verdict: dict,
+    note: str = "",
 ) -> str:
     """Build a markdown summary for GitHub step summary."""
     affected = verdict.get("affected", False)
@@ -51,6 +52,10 @@ def render_markdown(
         f"| **Confidence** | {confidence} |",
         f"| **Action** | {action_text} |",
         f"| **Package** | {package} |",
+    ]
+    if note:
+        lines.append(f"| **Note** | {note} |")
+    lines += [
         "",
         "### Analysis",
         "",
@@ -98,6 +103,7 @@ def write_step_summary(
     severity: str,
     action: str,
     verdict: dict,
+    note: str = "",
 ) -> None:
     """Write markdown summary to $GITHUB_STEP_SUMMARY and emit an annotation."""
     import os
@@ -105,7 +111,7 @@ def write_step_summary(
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_file:
         md = render_markdown(
-            repo_name, alert_number, package, severity, action, verdict
+            repo_name, alert_number, package, severity, action, verdict, note
         )
         with open(summary_file, "a") as f:
             f.write(md)

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -516,6 +516,26 @@ def main() -> None:
         severity_l = severity.lower()
         confidence = str(verdict.get("confidence", "")).lower()
 
+        # If dismissal is enabled but blocked (severity or confidence), record why —
+        # shown in the summary whether we then bump or no-op.
+        if (
+            dismiss_enabled
+            and not existing_pr
+            and not dismiss_allowed(
+                dismiss_enabled, severity_l, confidence, dismiss_min_confidence
+            )
+        ):
+            if (
+                severity_l in DISMISS_BLOCKED_SEVERITIES
+                or severity_l in DISMISS_UNKNOWN_SEVERITIES
+            ):
+                note = f"not dismissed: severity {severity_l} needs manual review"
+            else:
+                note = (
+                    f"not dismissed: confidence {confidence} "
+                    f"below required {dismiss_min_confidence}"
+                )
+
         if existing_pr:
             print(f"  Existing PR #{existing_pr} covers this package.")
             comment_on_pr(repo, existing_pr, reason, dry_run)
@@ -581,16 +601,6 @@ def main() -> None:
                     else:
                         action = "noop"
         elif dismiss_enabled:
-            if (
-                severity_l in DISMISS_BLOCKED_SEVERITIES
-                or severity_l in DISMISS_UNKNOWN_SEVERITIES
-            ):
-                note = f"not dismissed: severity {severity_l} needs manual review"
-            else:
-                note = (
-                    f"not dismissed: confidence {confidence} "
-                    f"below required {dismiss_min_confidence}"
-                )
             print(f"  {note}.")
             action = "noop"
         else:

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -480,6 +480,12 @@ def main() -> None:
         "yes",
     )
     dismiss_min_confidence = os.environ.get("DISMISS_MIN_CONFIDENCE", "high").lower()
+    if dismiss_min_confidence not in CONFIDENCE_RANK:
+        print(
+            f"  Unrecognized DISMISS_MIN_CONFIDENCE={dismiss_min_confidence!r}; "
+            "defaulting to 'high'."
+        )
+        dismiss_min_confidence = "high"
 
     if not token or not repo_name:
         print("Error: GH_TOKEN and REPO are required.")
@@ -532,7 +538,7 @@ def main() -> None:
                 note = f"not dismissed: severity {severity_l} needs manual review"
             else:
                 note = (
-                    f"not dismissed: confidence {confidence} "
+                    f"not dismissed: confidence {confidence or 'unknown'} "
                     f"below required {dismiss_min_confidence}"
                 )
 

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -43,6 +43,7 @@ from scripts.alert_report import write_step_summary  # noqa: E402
 BLENDER_NAME = "BLEnder"
 DISMISS_BLOCKED_SEVERITIES = {"critical", "high"}
 DISMISS_UNKNOWN_SEVERITIES = {"", "unknown"}
+CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
 VERDICT_FILE = ".blender-alert-verdict.json"
 REQUIRED_KEYS = {
     "affected",
@@ -51,6 +52,24 @@ REQUIRED_KEYS = {
     "vulnerable_paths",
     "recommended_action",
 }
+
+
+def dismiss_allowed(
+    enabled: bool,
+    severity: str,
+    confidence: str,
+    min_confidence: str,
+) -> bool:
+    """Whether a not-affected alert may be auto-dismissed.
+
+    Below the confidence bar is never dismissed, at any severity. Severity
+    scope (which severities are eligible at all) is handled separately.
+    """
+    if not enabled or severity in DISMISS_UNKNOWN_SEVERITIES:
+        return False
+    if severity in DISMISS_BLOCKED_SEVERITIES:
+        return False
+    return CONFIDENCE_RANK.get(confidence, 0) >= CONFIDENCE_RANK.get(min_confidence, 3)
 
 
 def load_verdict() -> dict | None:
@@ -460,6 +479,7 @@ def main() -> None:
         "1",
         "yes",
     )
+    dismiss_min_confidence = os.environ.get("DISMISS_MIN_CONFIDENCE", "high").lower()
 
     if not token or not repo_name:
         print("Error: GH_TOKEN and REPO are required.")
@@ -492,17 +512,19 @@ def main() -> None:
     if not affected:
         # Check for an existing PR (Dependabot or BLEnder) that bumps this package
         existing_pr = find_existing_bump_pr(repo, package_name)
+        severity_l = severity.lower()
+        confidence = str(verdict.get("confidence", "")).lower()
 
         if existing_pr:
             print(f"  Existing PR #{existing_pr} covers this package.")
             comment_on_pr(repo, existing_pr, reason, dry_run)
             action = "existing_pr"
-        elif (
-            dismiss_enabled
-            and severity.lower() not in DISMISS_BLOCKED_SEVERITIES
-            and severity.lower() not in DISMISS_UNKNOWN_SEVERITIES
+        elif dismiss_allowed(
+            dismiss_enabled, severity_l, confidence, dismiss_min_confidence
         ):
-            print("  Unaffected + dismiss enabled (low/medium). Dismissing alert.")
+            print(
+                f"  Unaffected + dismiss allowed ({severity_l}, confidence={confidence}). Dismissing alert."
+            )
             dismiss_alert(repo, alert_number, reason, dry_run)
             action = "dismissed"
         elif recommended == "bump_pr":
@@ -558,10 +580,15 @@ def main() -> None:
                     else:
                         action = "noop"
         elif dismiss_enabled:
-            print(
-                f"  Unaffected but severity is {severity}."
-                " Recommend manual review before dismissing."
-            )
+            if (
+                severity_l in DISMISS_BLOCKED_SEVERITIES
+                or severity_l in DISMISS_UNKNOWN_SEVERITIES
+            ):
+                print(f"  Not dismissed: severity {severity_l} needs manual review.")
+            else:
+                print(
+                    f"  Not dismissed: confidence {confidence} below required {dismiss_min_confidence}."
+                )
             action = "noop"
         else:
             action = "noop"

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -535,11 +535,14 @@ def main() -> None:
                 severity_l in DISMISS_BLOCKED_SEVERITIES
                 or severity_l in DISMISS_UNKNOWN_SEVERITIES
             ):
-                note = f"not dismissed: severity {severity_l} needs manual review"
+                note = (
+                    f"not dismissed. severity: {severity_l or 'unknown'}. "
+                    "needs manual review"
+                )
             else:
                 note = (
-                    f"not dismissed: confidence {confidence or 'unknown'} "
-                    f"below required {dismiss_min_confidence}"
+                    f"not dismissed. confidence: {confidence or 'unknown'}. "
+                    f"below required: {dismiss_min_confidence}"
                 )
 
         if existing_pr:

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -508,6 +508,7 @@ def main() -> None:
     print(f"  Reason: {verdict.get('reason', '(none)')}")
 
     reason = verdict.get("reason", "(none)")
+    note = ""  # extra context for the step summary (e.g. why a dismissal was skipped)
 
     if not affected:
         # Check for an existing PR (Dependabot or BLEnder) that bumps this package
@@ -584,11 +585,13 @@ def main() -> None:
                 severity_l in DISMISS_BLOCKED_SEVERITIES
                 or severity_l in DISMISS_UNKNOWN_SEVERITIES
             ):
-                print(f"  Not dismissed: severity {severity_l} needs manual review.")
+                note = f"not dismissed: severity {severity_l} needs manual review"
             else:
-                print(
-                    f"  Not dismissed: confidence {confidence} below required {dismiss_min_confidence}."
+                note = (
+                    f"not dismissed: confidence {confidence} "
+                    f"below required {dismiss_min_confidence}"
                 )
+            print(f"  {note}.")
             action = "noop"
         else:
             action = "noop"
@@ -611,7 +614,9 @@ def main() -> None:
         write_output("action", action)
         write_output("advisory_ghsa_id", ghsa_id)
 
-    write_step_summary(repo_name, alert_number, package_name, severity, action, verdict)
+    write_step_summary(
+        repo_name, alert_number, package_name, severity, action, verdict, note
+    )
 
 
 def write_output(key: str, value: str) -> None:

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -63,7 +63,7 @@ def dismiss_allowed(
     """Whether a not-affected alert may be auto-dismissed.
 
     Below the confidence bar is never dismissed, at any severity. Severity
-    scope (which severities are eligible at all) is handled separately.
+    scope is handled separately.
     """
     if not enabled or severity in DISMISS_UNKNOWN_SEVERITIES:
         return False

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -124,6 +124,14 @@ class TestRenderMarkdown:
         assert "not used in codebase" in result
         assert "dismissed" in result.lower()
 
+    def test_note_renders_when_present(self):
+        result = render_markdown(
+            "owner/repo", 42, "lodash", "low", "noop", SAMPLE_VERDICT,
+            note="not dismissed: confidence low below required high",
+        )
+        assert "**Note**" in result
+        assert "below required high" in result
+
     def test_affected_redacts_details(self):
         verdict = {
             "affected": True,
@@ -354,12 +362,15 @@ class TestMainFlow:
         mock_repo.full_name = "owner/repo"
         mock_repo.get_pulls.return_value = []
 
-        self._run_main(
+        summary_file = self._run_main(
             verdict_file, tmp_path, monkeypatch, mock_repo,
             DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
         )
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
+        # The skip reason must reach the step summary, not just the job log (#143).
+        summary = open(summary_file).read()
+        assert "below required high" in summary
 
     def test_dismiss_confidence_bar_configurable(
         self, verdict_file, tmp_path, monkeypatch

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -327,6 +327,60 @@ class TestMainFlow:
             },
         )
 
+    def test_dismiss_blocked_below_confidence(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Low-confidence not-affected verdicts are never dismissed (default bar=high)."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "low"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_dismiss_medium_confidence_blocked_by_default_bar(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Default bar is high, so a medium-confidence verdict does not dismiss."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_dismiss_confidence_bar_configurable(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Lowering the bar to medium lets a medium-confidence verdict dismiss."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+            DISMISS_MIN_CONFIDENCE="medium",
+        )
+
+        args = mock_repo._requester.requestJsonAndCheck.call_args
+        assert args.args[0] == "PATCH"
+        assert args.kwargs["input"]["state"] == "dismissed"
+
     def test_dismiss_skips_high_severity(
         self, verdict_file, tmp_path, monkeypatch
     ):

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -127,10 +127,10 @@ class TestRenderMarkdown:
     def test_note_renders_when_present(self):
         result = render_markdown(
             "owner/repo", 42, "lodash", "low", "noop", SAMPLE_VERDICT,
-            note="not dismissed: confidence low below required high",
+            note="not dismissed. confidence: low. below required: high",
         )
         assert "**Note**" in result
-        assert "below required high" in result
+        assert "below required: high" in result
 
     def test_affected_redacts_details(self):
         verdict = {
@@ -370,7 +370,7 @@ class TestMainFlow:
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
         # The skip reason must reach the step summary, not just the job log (#143).
         summary = open(summary_file).read()
-        assert "below required high" in summary
+        assert "below required: high" in summary
 
     def test_dismiss_confidence_bar_configurable(
         self, verdict_file, tmp_path, monkeypatch
@@ -408,7 +408,7 @@ class TestMainFlow:
         )
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
-        assert "confidence unknown below required high" in open(summary_file).read()
+        assert "confidence: unknown. below required: high" in open(summary_file).read()
 
     def test_invalid_min_confidence_falls_back_to_high(
         self, verdict_file, tmp_path, monkeypatch
@@ -485,7 +485,7 @@ class TestMainFlow:
         # Bumped (not dismissed) because confidence was below the bar...
         assert "action=npm_bump" in open(output_file).read()
         # ...and the summary still explains why it wasn't dismissed (#143).
-        assert "below required high" in open(summary_file).read()
+        assert "below required: high" in open(summary_file).read()
 
     def test_npm_bump_outputs_action(
         self, verdict_file, tmp_path, monkeypatch

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -392,6 +392,43 @@ class TestMainFlow:
         assert args.args[0] == "PATCH"
         assert args.kwargs["input"]["state"] == "dismissed"
 
+    def test_empty_confidence_note_is_readable(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """An empty confidence value renders a readable note, not a blank."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": ""}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        summary_file = self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+        assert "confidence unknown below required high" in open(summary_file).read()
+
+    def test_invalid_min_confidence_falls_back_to_high(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """An unrecognized DISMISS_MIN_CONFIDENCE defaults to the strict 'high' bar."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+            DISMISS_MIN_CONFIDENCE="hgih",  # typo -> falls back to high
+        )
+
+        # medium is below the fallback 'high' bar, so nothing is dismissed
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
     def test_dismiss_skips_high_severity(
         self, verdict_file, tmp_path, monkeypatch
     ):

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -425,6 +425,31 @@ class TestMainFlow:
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
 
+    def test_confidence_note_preserved_on_bump_fallback(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """A below-bar alert that recommends bump_pr still records the confidence note."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "bump_pr", "confidence": "low"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        output_file = str(tmp_path / "github_output")
+        open(output_file, "w").close()
+
+        summary_file = self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+            ALERT_ECOSYSTEM="npm", ALERT_PATCHED_VERSION="1.0.1",
+            GITHUB_OUTPUT=output_file,
+        )
+
+        # Bumped (not dismissed) because confidence was below the bar...
+        assert "action=npm_bump" in open(output_file).read()
+        # ...and the summary still explains why it wasn't dismissed (#143).
+        assert "below required high" in open(summary_file).read()
+
     def test_npm_bump_outputs_action(
         self, verdict_file, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What
Adds `investigate.dismiss_min_confidence` (`low` | `medium` | `high`, default **high**), applied to **every** dismissal regardless of severity. Nothing below the bar is dismissed; the reason is logged in the run.

## Why
Not-affected low/medium alerts were dismissed with **no confidence check** — including `low` ("cannot determine with confidence"). That's the gap: a verdict that can't determine impact should never auto-dismiss.

## Scope
Severity eligibility is **unchanged** here (high/critical still not dismissable). Making that a configurable ceiling is #144 (follow-up PR), which builds on this.

## Behavior change
fxa has `dismiss_unaffected: true` and no override, so it now defaults to `high` — only high-confidence not-affected verdicts dismiss. Prompt updated so the model reserves `confidence: high` for genuine certainty.

Closes #143