### PR TITLE
feat(investigate): configurable dismissable severity ceiling

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -79,6 +79,9 @@ outputs:
   dismiss_min_confidence:
     description: 'Minimum verdict confidence required to auto-dismiss'
     value: ${{ steps.config.outputs.dismiss_min_confidence }}
+  dismiss_max_severity:
+    description: 'Highest severity BLEnder may auto-dismiss'
+    value: ${{ steps.config.outputs.dismiss_max_severity }}
   install_failed:
     description: 'Whether the target dependency install failed'
     value: ${{ steps.install-deps.outcome == 'failure' && 'true' || 'false' }}
@@ -132,6 +135,7 @@ runs:
           echo "repo_name=$(yq '.repo_name // ""' "$CONFIG_FILE")"
           echo "dismiss_unaffected=$(yq '.investigate.dismiss_unaffected // "false"' "$CONFIG_FILE")"
           echo "dismiss_min_confidence=$(yq '.investigate.dismiss_min_confidence // "high"' "$CONFIG_FILE")"
+          echo "dismiss_max_severity=$(yq '.investigate.dismiss_max_severity // "medium"' "$CONFIG_FILE")"
         } >> "$GITHUB_OUTPUT"
       env:
         CHECKOUT_PATH: ${{ inputs.checkout-path }}

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -182,6 +182,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           DISMISS_UNAFFECTED: ${{ steps.setup.outputs.dismiss_unaffected }}
           DISMISS_MIN_CONFIDENCE: ${{ steps.setup.outputs.dismiss_min_confidence }}
+          DISMISS_MAX_SEVERITY: ${{ steps.setup.outputs.dismiss_max_severity }}
 
       # --- npm transitive dependency bump (lock file only) ---
       - name: Run npm audit fix

--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -22,9 +22,9 @@ investigate:
   severity_threshold: ""
   dismiss_unaffected: false
   # Minimum verdict confidence required to auto-dismiss: low | medium | high
-  # (a confidence floor for every dismissal; which severities are dismissable is
-  # separate)
   dismiss_min_confidence: high
+  # Highest severity BLEnder may auto-dismiss: low | medium | high | critical
+  dismiss_max_severity: medium
   # Max investigations per repo per sweep; the rest drain on later sweeps. 0 = unlimited.
   max_per_sweep: 50
 

--- a/scripts/github_utils.py
+++ b/scripts/github_utils.py
@@ -10,6 +10,9 @@ from github.PullRequest import PullRequest
 
 BOT_LOGIN = "mozilla-blender[bot]"
 
+# Dependabot alert severities, ranked low to high.
+SEVERITY_RANK = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+
 
 def is_bot(login: str) -> bool:
     """True if the login belongs to a bot account.

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -5,7 +5,7 @@ Reads .blender-alert-verdict.json and takes the appropriate action:
 
   unaffected + existing PR       -> comment on the PR, let other workflows handle
   unaffected + no PR             -> bump via lock tool or create PR
-  unaffected + dismiss enabled   -> dismiss the alert (low/medium only)
+  unaffected + dismiss enabled   -> dismiss if severity <= ceiling and confidence >= floor
   affected                       -> create advisory with private fork
 
 Writes a summary to $GITHUB_STEP_SUMMARY and emits an annotation.
@@ -19,7 +19,9 @@ Environment variables:
   ALERT_SEVERITY        -- Alert severity (optional, for summary)
   ALERT_PATCHED_VERSION -- Version to bump to (optional)
   DRY_RUN               -- Set to "true" to skip mutations (default: false)
-  DISMISS_UNAFFECTED    -- Set to "true" to dismiss unaffected alerts
+  DISMISS_UNAFFECTED     -- Set to "true" to dismiss unaffected alerts
+  DISMISS_MIN_CONFIDENCE -- Min confidence to dismiss: low|medium|high (default high)
+  DISMISS_MAX_SEVERITY   -- Highest severity to dismiss: low|medium|high|critical (default medium)
 """
 
 from __future__ import annotations
@@ -39,10 +41,9 @@ if _repo_root not in sys.path:
 from github import Auth, Github  # noqa: E402
 
 from scripts.alert_report import write_step_summary  # noqa: E402
+from scripts.github_utils import SEVERITY_RANK  # noqa: E402
 
 BLENDER_NAME = "BLEnder"
-DISMISS_BLOCKED_SEVERITIES = {"critical", "high"}
-DISMISS_UNKNOWN_SEVERITIES = {"", "unknown"}
 CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
 VERDICT_FILE = ".blender-alert-verdict.json"
 REQUIRED_KEYS = {
@@ -54,20 +55,27 @@ REQUIRED_KEYS = {
 }
 
 
+def severity_over_ceiling(severity: str, max_severity: str) -> bool:
+    """True if severity is unrecognized or ranks above the dismissal ceiling.
+
+    Unrecognized severities map to rank 99 so they are never auto-dismissed.
+    """
+    return SEVERITY_RANK.get(severity, 99) > SEVERITY_RANK.get(max_severity, 0)
+
+
 def dismiss_allowed(
     enabled: bool,
     severity: str,
     confidence: str,
     min_confidence: str,
+    max_severity: str,
 ) -> bool:
     """Whether a not-affected alert may be auto-dismissed.
 
-    Below the confidence bar is never dismissed, at any severity. Severity
-    scope is handled separately.
+    Dismissed only when severity is recognized and at or below the configured
+    ceiling and the verdict confidence meets the configured floor.
     """
-    if not enabled or severity in DISMISS_UNKNOWN_SEVERITIES:
-        return False
-    if severity in DISMISS_BLOCKED_SEVERITIES:
+    if not enabled or severity_over_ceiling(severity, max_severity):
         return False
     return CONFIDENCE_RANK.get(confidence, 0) >= CONFIDENCE_RANK.get(min_confidence, 3)
 
@@ -486,6 +494,13 @@ def main() -> None:
             "defaulting to 'high'."
         )
         dismiss_min_confidence = "high"
+    dismiss_max_severity = os.environ.get("DISMISS_MAX_SEVERITY", "medium").lower()
+    if dismiss_max_severity not in SEVERITY_RANK:
+        print(
+            f"  Unrecognized DISMISS_MAX_SEVERITY={dismiss_max_severity!r}; "
+            "defaulting to 'medium'."
+        )
+        dismiss_max_severity = "medium"
 
     if not token or not repo_name:
         print("Error: GH_TOKEN and REPO are required.")
@@ -521,23 +536,26 @@ def main() -> None:
         existing_pr = find_existing_bump_pr(repo, package_name)
         severity_l = severity.lower()
         confidence = str(verdict.get("confidence", "")).lower()
+        allowed = dismiss_allowed(
+            dismiss_enabled,
+            severity_l,
+            confidence,
+            dismiss_min_confidence,
+            dismiss_max_severity,
+        )
 
         # If dismissal is enabled but blocked (severity or confidence), record why —
         # shown in the summary whether we then bump or no-op.
-        if (
-            dismiss_enabled
-            and not existing_pr
-            and not dismiss_allowed(
-                dismiss_enabled, severity_l, confidence, dismiss_min_confidence
-            )
-        ):
-            if (
-                severity_l in DISMISS_BLOCKED_SEVERITIES
-                or severity_l in DISMISS_UNKNOWN_SEVERITIES
-            ):
+        if dismiss_enabled and not existing_pr and not allowed:
+            if severity_l not in SEVERITY_RANK:
                 note = (
                     f"not dismissed. severity: {severity_l or 'unknown'}. "
                     "needs manual review"
+                )
+            elif severity_over_ceiling(severity_l, dismiss_max_severity):
+                note = (
+                    f"not dismissed. severity: {severity_l}. "
+                    f"above ceiling: {dismiss_max_severity}"
                 )
             else:
                 note = (
@@ -549,9 +567,7 @@ def main() -> None:
             print(f"  Existing PR #{existing_pr} covers this package.")
             comment_on_pr(repo, existing_pr, reason, dry_run)
             action = "existing_pr"
-        elif dismiss_allowed(
-            dismiss_enabled, severity_l, confidence, dismiss_min_confidence
-        ):
+        elif allowed:
             print(
                 f"  Unaffected + dismiss allowed ({severity_l}, confidence={confidence}). Dismissing alert."
             )

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -534,11 +534,11 @@ def main() -> None:
     if not affected:
         # Check for an existing PR (Dependabot or BLEnder) that bumps this package
         existing_pr = find_existing_bump_pr(repo, package_name)
-        severity_l = severity.lower()
+        severity_lower = severity.lower()
         confidence = str(verdict.get("confidence", "")).lower()
         allowed = dismiss_allowed(
             dismiss_enabled,
-            severity_l,
+            severity_lower,
             confidence,
             dismiss_min_confidence,
             dismiss_max_severity,
@@ -547,14 +547,14 @@ def main() -> None:
         # If dismissal is enabled but blocked (severity or confidence), record why —
         # shown in the summary whether we then bump or no-op.
         if dismiss_enabled and not existing_pr and not allowed:
-            if severity_l not in SEVERITY_RANK:
+            if severity_lower not in SEVERITY_RANK:
                 note = (
-                    f"not dismissed. severity: {severity_l or 'unknown'}. "
+                    f"not dismissed. severity: {severity_lower or 'unknown'}. "
                     "needs manual review"
                 )
-            elif severity_over_ceiling(severity_l, dismiss_max_severity):
+            elif severity_over_ceiling(severity_lower, dismiss_max_severity):
                 note = (
-                    f"not dismissed. severity: {severity_l}. "
+                    f"not dismissed. severity: {severity_lower}. "
                     f"above ceiling: {dismiss_max_severity}"
                 )
             else:
@@ -569,7 +569,7 @@ def main() -> None:
             action = "existing_pr"
         elif allowed:
             print(
-                f"  Unaffected + dismiss allowed ({severity_l}, confidence={confidence}). Dismissing alert."
+                f"  Unaffected + dismiss allowed ({severity_lower}, confidence={confidence}). Dismissing alert."
             )
             dismiss_alert(repo, alert_number, reason, dry_run)
             action = "dismissed"

--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -534,11 +534,11 @@ def main() -> None:
     if not affected:
         # Check for an existing PR (Dependabot or BLEnder) that bumps this package
         existing_pr = find_existing_bump_pr(repo, package_name)
-        severity_lower = severity.lower()
+        severity_lowercase = severity.lower()
         confidence = str(verdict.get("confidence", "")).lower()
         allowed = dismiss_allowed(
             dismiss_enabled,
-            severity_lower,
+            severity_lowercase,
             confidence,
             dismiss_min_confidence,
             dismiss_max_severity,
@@ -547,14 +547,14 @@ def main() -> None:
         # If dismissal is enabled but blocked (severity or confidence), record why —
         # shown in the summary whether we then bump or no-op.
         if dismiss_enabled and not existing_pr and not allowed:
-            if severity_lower not in SEVERITY_RANK:
+            if severity_lowercase not in SEVERITY_RANK:
                 note = (
-                    f"not dismissed. severity: {severity_lower or 'unknown'}. "
+                    f"not dismissed. severity: {severity_lowercase or 'unknown'}. "
                     "needs manual review"
                 )
-            elif severity_over_ceiling(severity_lower, dismiss_max_severity):
+            elif severity_over_ceiling(severity_lowercase, dismiss_max_severity):
                 note = (
-                    f"not dismissed. severity: {severity_lower}. "
+                    f"not dismissed. severity: {severity_lowercase}. "
                     f"above ceiling: {dismiss_max_severity}"
                 )
             else:
@@ -569,7 +569,7 @@ def main() -> None:
             action = "existing_pr"
         elif allowed:
             print(
-                f"  Unaffected + dismiss allowed ({severity_lower}, confidence={confidence}). Dismissing alert."
+                f"  Unaffected + dismiss allowed ({severity_lowercase}, confidence={confidence}). Dismissing alert."
             )
             dismiss_alert(repo, alert_number, reason, dry_run)
             action = "dismissed"

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -37,10 +37,14 @@ from github.Repository import Repository
 
 try:
     from scripts.config_utils import load_repo_config
-    from scripts.github_utils import has_codeowner_approval, is_bot
+    from scripts.github_utils import SEVERITY_RANK, has_codeowner_approval, is_bot
 except ImportError:
     from config_utils import load_repo_config  # type: ignore[no-redef]
-    from github_utils import has_codeowner_approval, is_bot  # type: ignore[no-redef]
+    from github_utils import (  # type: ignore[no-redef]
+        SEVERITY_RANK,
+        has_codeowner_approval,
+        is_bot,
+    )
 
 BOT_LOGIN = "mozilla-blender[bot]"
 
@@ -55,10 +59,6 @@ ALLOWED_OWNERS = frozenset(
 BLENDER_REPO = "mozilla/blender"
 INVESTIGATED_TAG_PREFIX = "investigated/"
 _INVESTIGATED_TAG_RE = re.compile(r"^investigated/(.+)/(\d+)$")
-
-# Dependabot alert severities, ranked low to high. Used to skip alerts
-# below a repo's configured investigate.severity_threshold.
-SEVERITY_RANK = {"low": 1, "medium": 2, "high": 3, "critical": 4}
 
 
 AUTO_ENGINEER_LABEL = "blender:auto-engineer"

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -47,6 +47,28 @@ SAMPLE_VERDICT = {
 }
 
 
+# Dismissal policy cases exercised through main() (see TestMainFlow).
+# Each: (id, extra env, verdict overrides, expected step-summary note substring).
+NOT_DISMISSED_CASES = [
+    ("low_confidence", {"ALERT_SEVERITY": "low"}, {"confidence": "low"}, "below required: high"),
+    ("medium_below_default_bar", {"ALERT_SEVERITY": "low"}, {"confidence": "medium"}, "below required: high"),
+    ("empty_confidence", {"ALERT_SEVERITY": "low"}, {"confidence": ""}, "confidence: unknown. below required: high"),
+    ("invalid_min_confidence", {"ALERT_SEVERITY": "low", "DISMISS_MIN_CONFIDENCE": "hgih"}, {"confidence": "medium"}, None),
+    ("high_above_default_ceiling", {"ALERT_SEVERITY": "high"}, {"confidence": "high"}, "above ceiling: medium"),
+    ("critical_above_high_ceiling", {"ALERT_SEVERITY": "critical", "DISMISS_MAX_SEVERITY": "high"}, {"confidence": "high"}, "above ceiling: high"),
+    ("invalid_max_severity", {"ALERT_SEVERITY": "high", "DISMISS_MAX_SEVERITY": "huge"}, {"confidence": "high"}, None),
+    ("unknown_severity", {"ALERT_SEVERITY": ""}, {"confidence": "high"}, "needs manual review"),
+    ("unrecognized_severity", {"ALERT_SEVERITY": "moderate", "DISMISS_MAX_SEVERITY": "critical"}, {"confidence": "high"}, "needs manual review"),
+]
+
+DISMISSED_CASES = [
+    ("low_default_bar", {"ALERT_SEVERITY": "low"}, {"confidence": "high"}),
+    ("medium_bar_lowered", {"ALERT_SEVERITY": "low", "DISMISS_MIN_CONFIDENCE": "medium"}, {"confidence": "medium"}),
+    ("high_ceiling_raised", {"ALERT_SEVERITY": "high", "DISMISS_MAX_SEVERITY": "high"}, {"confidence": "high"}),
+    ("critical_ceiling", {"ALERT_SEVERITY": "critical", "DISMISS_MAX_SEVERITY": "critical"}, {"confidence": "high"}),
+]
+
+
 class TestLoadVerdict:
     def test_missing_file(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -310,53 +332,17 @@ class TestMainFlow:
         # Should comment on PR, not dismiss
         mock_repo.get_pull.assert_called_once_with(99)
 
-    def test_dismiss_enabled_no_pr_no_bump(
-        self, verdict_file, tmp_path, monkeypatch
+    @pytest.mark.parametrize(
+        "env, verdict_over, note_substr",
+        [c[1:] for c in NOT_DISMISSED_CASES],
+        ids=[c[0] for c in NOT_DISMISSED_CASES],
+    )
+    def test_unaffected_not_dismissed(
+        self, verdict_file, tmp_path, monkeypatch, env, verdict_over, note_substr
     ):
-        """With dismiss enabled and recommended_action != bump_pr, dismiss."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_called_once_with(
-            "PATCH",
-            "/repos/owner/repo/dependabot/alerts/42",
-            input={
-                "state": "dismissed",
-                "dismissed_reason": "not_used",
-                "dismissed_comment": "BLEnder: not used in codebase",
-            },
-        )
-
-    def test_dismiss_blocked_below_confidence(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """Low-confidence not-affected verdicts are never dismissed (default bar=high)."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "low"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-
-    def test_dismiss_medium_confidence_blocked_by_default_bar(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """Default bar is high, so a medium-confidence verdict does not dismiss."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        """Not-affected alerts blocked by the confidence floor or severity ceiling
+        are left open, with the reason recorded in the step summary."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", **verdict_over}
         verdict_file(verdict)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
@@ -364,19 +350,24 @@ class TestMainFlow:
 
         summary_file = self._run_main(
             verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
+            DISMISS_UNAFFECTED="true", **env,
         )
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
-        # The skip reason must reach the step summary, not just the job log (#143).
-        summary = open(summary_file).read()
-        assert "below required: high" in summary
+        if note_substr:
+            assert note_substr in open(summary_file).read()
 
-    def test_dismiss_confidence_bar_configurable(
-        self, verdict_file, tmp_path, monkeypatch
+    @pytest.mark.parametrize(
+        "env, verdict_over",
+        [c[1:] for c in DISMISSED_CASES],
+        ids=[c[0] for c in DISMISSED_CASES],
+    )
+    def test_unaffected_dismissed_within_policy(
+        self, verdict_file, tmp_path, monkeypatch, env, verdict_over
     ):
-        """Lowering the bar to medium lets a medium-confidence verdict dismiss."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
+        """Not-affected alerts within the severity ceiling and confidence floor
+        are dismissed."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", **verdict_over}
         verdict_file(verdict)
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
@@ -384,177 +375,12 @@ class TestMainFlow:
 
         self._run_main(
             verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
-            DISMISS_MIN_CONFIDENCE="medium",
+            DISMISS_UNAFFECTED="true", **env,
         )
 
         args = mock_repo._requester.requestJsonAndCheck.call_args
         assert args.args[0] == "PATCH"
         assert args.kwargs["input"]["state"] == "dismissed"
-
-    def test_empty_confidence_note_is_readable(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """An empty confidence value renders a readable note, not a blank."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": ""}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        summary_file = self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-        assert "confidence: unknown. below required: high" in open(summary_file).read()
-
-    def test_invalid_min_confidence_falls_back_to_high(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """An unrecognized DISMISS_MIN_CONFIDENCE defaults to the strict 'high' bar."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "medium"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="low",
-            DISMISS_MIN_CONFIDENCE="hgih",  # typo -> falls back to high
-        )
-
-        # medium is below the fallback 'high' bar, so nothing is dismissed
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-
-    def test_dismiss_skips_high_severity(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="high",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-
-    def test_dismiss_high_when_ceiling_raised(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """High is dismissed when the ceiling is raised to high and confidence clears the bar."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="high",
-            DISMISS_MAX_SEVERITY="high",
-        )
-
-        args = mock_repo._requester.requestJsonAndCheck.call_args
-        assert args.args[0] == "PATCH"
-        assert args.kwargs["input"]["state"] == "dismissed"
-
-    def test_dismiss_critical_when_ceiling_is_critical(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """Critical is dismissable only when the ceiling is explicitly critical."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="critical",
-            DISMISS_MAX_SEVERITY="critical",
-        )
-
-        assert mock_repo._requester.requestJsonAndCheck.call_args.args[0] == "PATCH"
-
-    def test_critical_not_dismissed_below_ceiling(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """Critical stays open when the ceiling is only high; the reason lands in the summary."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        summary_file = self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="critical",
-            DISMISS_MAX_SEVERITY="high",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-        assert "above ceiling: high" in open(summary_file).read()
-
-    def test_invalid_max_severity_falls_back_to_medium(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """An unrecognized DISMISS_MAX_SEVERITY defaults to 'medium' (high not dismissed)."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="high",
-            DISMISS_MAX_SEVERITY="huge",  # typo -> falls back to medium
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-
-    def test_unrecognized_severity_not_dismissed(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """A non-canonical severity is never dismissed and reads as manual-review, not 'above ceiling'."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        summary_file = self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="moderate",
-            DISMISS_MAX_SEVERITY="critical",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
-        assert "needs manual review" in open(summary_file).read()
-
-    def test_dismiss_skips_unknown_severity(
-        self, verdict_file, tmp_path, monkeypatch
-    ):
-        """Empty/unknown severity is not auto-dismissed (could be high/critical)."""
-        verdict = {**SAMPLE_VERDICT, "recommended_action": "none"}
-        verdict_file(verdict)
-        mock_repo = MagicMock()
-        mock_repo.full_name = "owner/repo"
-        mock_repo.get_pulls.return_value = []
-
-        self._run_main(
-            verdict_file, tmp_path, monkeypatch, mock_repo,
-            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="",
-        )
-
-        mock_repo._requester.requestJsonAndCheck.assert_not_called()
 
     def test_confidence_note_preserved_on_bump_fallback(
         self, verdict_file, tmp_path, monkeypatch

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -445,6 +445,100 @@ class TestMainFlow:
 
         mock_repo._requester.requestJsonAndCheck.assert_not_called()
 
+    def test_dismiss_high_when_ceiling_raised(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """High is dismissed when the ceiling is raised to high and confidence clears the bar."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="high",
+            DISMISS_MAX_SEVERITY="high",
+        )
+
+        args = mock_repo._requester.requestJsonAndCheck.call_args
+        assert args.args[0] == "PATCH"
+        assert args.kwargs["input"]["state"] == "dismissed"
+
+    def test_dismiss_critical_when_ceiling_is_critical(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Critical is dismissable only when the ceiling is explicitly critical."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="critical",
+            DISMISS_MAX_SEVERITY="critical",
+        )
+
+        assert mock_repo._requester.requestJsonAndCheck.call_args.args[0] == "PATCH"
+
+    def test_critical_not_dismissed_below_ceiling(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """Critical stays open when the ceiling is only high; the reason lands in the summary."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        summary_file = self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="critical",
+            DISMISS_MAX_SEVERITY="high",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+        assert "above ceiling: high" in open(summary_file).read()
+
+    def test_invalid_max_severity_falls_back_to_medium(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """An unrecognized DISMISS_MAX_SEVERITY defaults to 'medium' (high not dismissed)."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="high",
+            DISMISS_MAX_SEVERITY="huge",  # typo -> falls back to medium
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+
+    def test_unrecognized_severity_not_dismissed(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """A non-canonical severity is never dismissed and reads as manual-review, not 'above ceiling'."""
+        verdict = {**SAMPLE_VERDICT, "recommended_action": "none", "confidence": "high"}
+        verdict_file(verdict)
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = []
+
+        summary_file = self._run_main(
+            verdict_file, tmp_path, monkeypatch, mock_repo,
+            DISMISS_UNAFFECTED="true", ALERT_SEVERITY="moderate",
+            DISMISS_MAX_SEVERITY="critical",
+        )
+
+        mock_repo._requester.requestJsonAndCheck.assert_not_called()
+        assert "needs manual review" in open(summary_file).read()
+
     def test_dismiss_skips_unknown_severity(
         self, verdict_file, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What
Adds `investigate.dismiss_max_severity` (`low` | `medium` | `high` | `critical`, default **medium**) — the highest severity BLEnder may auto-dismiss. Replaces the previously hardcoded high/critical block.

## Combined rule (with #145)
An alert is auto-dismissed only when: `not affected` **AND** `severity ≤ dismiss_max_severity` **AND** `confidence ≥ dismiss_min_confidence`.

Confidence is the safety rail; severity is the opt-in scope. A repo confident it's unaffected can raise the ceiling all the way to `critical` — but a critical still only dismisses at the confidence floor (default `high`).

## Details
- Unknown severity is never dismissed; an invalid `dismiss_max_severity` warns and falls back to `medium`.
- The skip reason (`severity X above ceiling Y`) is surfaced in the step summary.
- Tests: high dismissed when ceiling raised, critical only at `critical` ceiling, critical blocked below ceiling (with summary note), invalid-value fallback.

Closes #144.