### PR TITLE
fix(yarn): stop Yarn Berry hijacking the bump env vars

### DIFF
--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -238,8 +238,8 @@ jobs:
         working-directory: target
         run: bash ${{ github.workspace }}/scripts/yarn-fix.sh
         env:
-          YARN_PACKAGE: ${{ steps.post-action.outputs.yarn_package }}
-          YARN_VERSION: ${{ steps.post-action.outputs.yarn_version }}
+          BUMP_PACKAGE: ${{ steps.post-action.outputs.yarn_package }}
+          BUMP_VERSION: ${{ steps.post-action.outputs.yarn_version }}
 
       - name: Create yarn bump PR
         if: >-

--- a/scripts/yarn-fix.sh
+++ b/scripts/yarn-fix.sh
@@ -2,12 +2,12 @@
 # BLEnder yarn fix (Berry v2+): bump a dependency and update yarn.lock only.
 # Writes fixed=true|false to $GITHUB_OUTPUT. Classic yarn v1 is not supported.
 #
-#   YARN_PACKAGE  -- package name (required)
-#   YARN_VERSION  -- patched version, used only in messages (optional)
+#   BUMP_PACKAGE  -- package name (required)
+#   BUMP_VERSION  -- patched version, used only in messages (optional)
 
 set -euo pipefail
 
-: "${YARN_PACKAGE:?YARN_PACKAGE is required}"
+: "${BUMP_PACKAGE:?BUMP_PACKAGE is required}"
 
 out() { echo "$1=$2" >> "${GITHUB_OUTPUT:-/dev/null}"; }
 
@@ -29,7 +29,7 @@ case "$YARN_VER" in
     ;;
 esac
 
-yarn why "$YARN_PACKAGE" 2>/dev/null || true
+yarn why "$BUMP_PACKAGE" 2>/dev/null || true
 
 # Package audit state: clean | flagged | error (error = audit run failed).
 pkg_audit_state() {
@@ -46,49 +46,49 @@ pkg_audit_state() {
 }
 
 # -R takes the package name only (a version/range is rejected).
-echo "Running: yarn up -R ${YARN_PACKAGE} --mode=update-lockfile"
-yarn up -R "$YARN_PACKAGE" --mode=update-lockfile \
-  || echo "::warning ::'yarn up -R ${YARN_PACKAGE}' failed; trying a resolution."
+echo "Running: yarn up -R ${BUMP_PACKAGE} --mode=update-lockfile"
+yarn up -R "$BUMP_PACKAGE" --mode=update-lockfile \
+  || echo "::warning ::'yarn up -R ${BUMP_PACKAGE}' failed; trying a resolution."
 
-state=$(pkg_audit_state "$YARN_PACKAGE")
+state=$(pkg_audit_state "$BUMP_PACKAGE")
 if [ "$state" = "error" ]; then
-  echo "::warning ::yarn npm audit failed to run — cannot verify ${YARN_PACKAGE}; treating as unremediated."
+  echo "::warning ::yarn npm audit failed to run — cannot verify ${BUMP_PACKAGE}; treating as unremediated."
   out fixed false
   exit 0
 fi
 
 # Out-of-range patch: fall back to a resolutions pin, single-major trees only (#122).
 if [ "$state" = "flagged" ]; then
-  majors=$(yarn why "$YARN_PACKAGE" --json 2>/dev/null \
+  majors=$(yarn why "$BUMP_PACKAGE" --json 2>/dev/null \
     | jq -r '.children | keys[] | capture("@npm:(?<v>[0-9]+)").v' 2>/dev/null \
     | sort -u | grep -c .)
-  if [ -n "${YARN_VERSION:-}" ] && [ "$majors" = "1" ]; then
-    echo "In-range bump insufficient; pinning ${YARN_PACKAGE} to ${YARN_VERSION} via resolutions."
-    jq --arg p "$YARN_PACKAGE" --arg v "$YARN_VERSION" \
+  if [ -n "${BUMP_VERSION:-}" ] && [ "$majors" = "1" ]; then
+    echo "In-range bump insufficient; pinning ${BUMP_PACKAGE} to ${BUMP_VERSION} via resolutions."
+    jq --arg p "$BUMP_PACKAGE" --arg v "$BUMP_VERSION" \
       '.resolutions = ((.resolutions // {}) + {($p): $v})' package.json > package.json.tmp \
       && mv package.json.tmp package.json
     if ! yarn install --mode=update-lockfile; then
-      echo "::warning ::yarn install failed after pinning ${YARN_PACKAGE} — treating as unremediated."
+      echo "::warning ::yarn install failed after pinning ${BUMP_PACKAGE} — treating as unremediated."
       out fixed false
       exit 0
     fi
   else
-    echo "::warning ::${YARN_PACKAGE} needs a resolution but has multiple major lines (or no patched version) — manual review needed (#122)."
+    echo "::warning ::${BUMP_PACKAGE} needs a resolution but has multiple major lines (or no patched version) — manual review needed (#122)."
     out fixed false
     exit 0
   fi
 fi
 
-if [ "$(pkg_audit_state "$YARN_PACKAGE")" != "clean" ]; then
-  echo "::warning ::${YARN_PACKAGE} not verified clear after remediation — manual review needed (#122)."
+if [ "$(pkg_audit_state "$BUMP_PACKAGE")" != "clean" ]; then
+  echo "::warning ::${BUMP_PACKAGE} not verified clear after remediation — manual review needed (#122)."
   out fixed false
   exit 0
 fi
 if git diff --quiet yarn.lock package.json 2>/dev/null; then
-  echo "::warning ::no changes produced for ${YARN_PACKAGE}; nothing to open."
+  echo "::warning ::no changes produced for ${BUMP_PACKAGE}; nothing to open."
   out fixed false
   exit 0
 fi
 
-echo "${YARN_PACKAGE} cleared in yarn npm audit."
+echo "${BUMP_PACKAGE} cleared in yarn npm audit."
 out fixed true


### PR DESCRIPTION
## Bug
BLEnder's yarn-bump remediation has been **silently failing on every yarn (Berry) repo**, so it never opened a bump PR. Yarn Berry reads any `YARN_<NAME>` environment variable as a config setting; the bump step passed the target via `YARN_PACKAGE`/`YARN_VERSION`, so every `yarn` call in `yarn-fix.sh` aborted with:

```
Usage Error: Unrecognized or legacy configuration settings found: package
```

`yarn up` never ran → resolution fallback found no change → "nothing to open". No error surfaced anywhere except the run log.

## Evidence
mozilla/fxa alert #913 (@simplewebauthn/server), run [33902016880](https://github.com/mozilla/blender/actions/runs/33902016880): verdict `not affected / bump_pr`, then the Usage Error above and "no changes produced … nothing to open."

## Fix
Rename the env vars to `BUMP_PACKAGE`/`BUMP_VERSION` (off the `YARN_` prefix) in the workflow step and `yarn-fix.sh`, with a note so nobody reintroduces a `YARN_*` name.

Closes #152