### PR TITLE
ci: suppress zizmor self-repository audit

### DIFF
--- a/.github/workflows/auto-engineer.yml
+++ b/.github/workflows/auto-engineer.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}
@@ -189,7 +189,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}
@@ -280,7 +280,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}

--- a/.github/workflows/fix-dependabot-pr.yml
+++ b/.github/workflows/fix-dependabot-pr.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}

--- a/.github/workflows/investigate-security-alert.yml
+++ b/.github/workflows/investigate-security-alert.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Setup target repo
         id: setup
-        uses: ./.github/actions/setup-target
+        uses: ./.github/actions/setup-target  # zizmor: ignore[self-repository]
         with:
           target-repo: ${{ inputs.target_repo }}
           app-id: ${{ secrets.BLENDER_APP_ID }}


### PR DESCRIPTION
Per review, we don't want to pin zizmor, but the recommended fix for its `self-repository` finding (`uses: $/...` GitHub's July-2026 syntax) is rejected by actionlint ("invalid format because ref is missing"), so the two linters conflict and `$/` isn't viable yet.

Compromise: keep zizmor unpinned (all latest checks) and suppress only the `self-repository` audit inline (`# zizmor: ignore[self-repository]`), leaving `uses: ./...` as-is. Revisit `$/` once actionlint supports it.

Closes #153. Unblocks #151.

Follow-up to switch to `$/` and drop the suppressions once actionlint supports it: #157