### PR TITLE
fix(investigate): upsert BLEnder's PR comment instead of duplicating

### DIFF
--- a/scripts/post_alert_action.py
+++ b/scripts/post_alert_action.py
@@ -44,6 +44,8 @@ from scripts.alert_report import write_step_summary  # noqa: E402
 from scripts.github_utils import SEVERITY_RANK  # noqa: E402
 
 BLENDER_NAME = "BLEnder"
+# Hidden marker so BLEnder can find and update its own investigate comment.
+COMMENT_MARKER = "<!-- blender-investigated -->"
 CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
 VERDICT_FILE = ".blender-alert-verdict.json"
 REQUIRED_KEYS = {
@@ -203,19 +205,31 @@ def comment_on_pr(
     reason: str,
     dry_run: bool,
 ) -> None:
-    """Comment on a PR with BLEnder's investigation results."""
+    """Comment on a PR with BLEnder's investigation results.
+
+    Upserts: if BLEnder already left an investigate comment on this PR, edit it
+    in place rather than adding a duplicate. This keeps one current comment per
+    PR — no spam when several alerts share a package, and a re-investigation
+    refreshes the comment instead of piling on (or going silent).
+    """
     run_link = _run_url()
     investigated = f"[investigated]({run_link})" if run_link else "investigated"
     body = (
         f"**{BLENDER_NAME} {investigated}:** This dependency has an open "
         f"security alert, but the repo is **not affected**.\n\n> {reason}\n\n"
-        "This PR can be reviewed and merged as a normal dependency update."
+        "This PR can be reviewed and merged as a normal dependency update.\n"
+        f"{COMMENT_MARKER}"
     )
     if dry_run:
         print(f"  DRY_RUN: would comment on PR #{pr_number}")
         return
 
     pr = repo.get_pull(pr_number)
+    for comment in pr.get_issue_comments():
+        if COMMENT_MARKER in (comment.body or ""):
+            comment.edit(body)
+            print(f"  Updated existing BLEnder comment on PR #{pr_number}")
+            return
     pr.create_issue_comment(body)
     print(f"  Commented on PR #{pr_number}")
 

--- a/tests/scripts/test_post_alert_action.py
+++ b/tests/scripts/test_post_alert_action.py
@@ -282,6 +282,7 @@ class TestMainFlow:
         mock_repo = MagicMock()
         mock_repo.full_name = "owner/repo"
         mock_repo.get_pulls.return_value = [mock_pr]
+        mock_repo.get_pull.return_value.get_issue_comments.return_value = []
 
         summary_file = self._run_main(
             verdict_file, tmp_path, monkeypatch, mock_repo
@@ -291,6 +292,27 @@ class TestMainFlow:
         mock_repo.get_pull.return_value.create_issue_comment.assert_called_once()
         content = open(summary_file).read()
         assert "Existing" in content
+
+    def test_existing_pr_updates_prior_comment(
+        self, verdict_file, tmp_path, monkeypatch
+    ):
+        """A second alert on the same PR edits BLEnder's comment, not duplicate it."""
+        verdict_file(SAMPLE_VERDICT)
+        mock_pr = MagicMock()
+        mock_pr.number = 99
+        mock_pr.title = "Bump lodash from 4.17.20 to 4.17.21"
+        mock_pr.user.login = "dependabot[bot]"
+        mock_repo = MagicMock()
+        mock_repo.full_name = "owner/repo"
+        mock_repo.get_pulls.return_value = [mock_pr]
+        prior = MagicMock()
+        prior.body = "**BLEnder investigated:** ...\n<!-- blender-investigated -->"
+        mock_repo.get_pull.return_value.get_issue_comments.return_value = [prior]
+
+        self._run_main(verdict_file, tmp_path, monkeypatch, mock_repo)
+
+        prior.edit.assert_called_once()
+        mock_repo.get_pull.return_value.create_issue_comment.assert_not_called()
 
     def test_existing_pr_dry_run_skips_comment(
         self, verdict_file, tmp_path, monkeypatch


### PR DESCRIPTION
## Bug
`comment_on_pr` creates a comment unconditionally, so when several alerts share a bump PR, each not-affected investigation adds its own — **4 near-identical comments on mozilla/fxa#21173** (axios). Not a loop (all tagged), but noisy.

## Fix
Tag the comment with a hidden marker (`<!-- blender-investigated -->`) and **upsert**: edit the existing BLEnder comment if present, else create.

## Why upsert, not skip
"Skip if a comment exists" would go silent on an **intentional** re-investigation (cleared tag + retrigger), hiding a possibly-changed verdict. Upsert keeps one always-current comment — no spam, and re-triggers refresh it.

Tests: create when none exists; edit (not duplicate) when a prior marked comment exists.

Closes #158.