### PR TITLE
fix(bump): title bump PRs with >= the advisory minimum, not an exact version

### DIFF
--- a/scripts/pip-lock-bump.sh
+++ b/scripts/pip-lock-bump.sh
@@ -65,9 +65,12 @@ if [ -n "$EXISTING_PR" ]; then
   exit 0
 fi
 
-COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+TARGET=$(bump_target)
+COMMIT_MSG="chore(deps): bump ${PACKAGE} to ${TARGET}
 
-Resolves Dependabot alert #${ALERT_NUMBER}.
+Resolves Dependabot alert #${ALERT_NUMBER}. The bump installs the highest
+version satisfying the dependency range; the title uses >=<min> when the
+advisory provides a minimum patched version — see the lock files for the exact resolved version.
 Created by BLEnder (https://github.com/mozilla/blender)"
 
 DEFAULT_BRANCH=$(gh api "repos/${REPO}" --jq '.default_branch')
@@ -82,7 +85,7 @@ echo "Created branch ${BRANCH_NAME} with commit ${COMMIT_SHA}"
 
 # Build PR body
 RUN_LINK=$(run_link)
-ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
+ALERT_LINE=$(bump_alert_line "$REPO" "$PACKAGE" "$TARGET" "$ALERT_NUMBER")
 
 PR_BODY="## Summary
 
@@ -93,7 +96,7 @@ This is a transitive dependency update via \`${PIP_LOCK_TOOL}\`. Only lock files
 ---
 *Created by ${RUN_LINK} via [BLEnder](https://github.com/mozilla/blender)*"
 
-PR_TITLE="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}"
+PR_TITLE="chore(deps): bump ${PACKAGE} to ${TARGET}"
 
 gh pr create \
   --repo "$REPO" \

--- a/scripts/pr-lib.sh
+++ b/scripts/pr-lib.sh
@@ -114,8 +114,8 @@ open_bump_pr() {
   local commit_msg="chore(deps): bump ${PACKAGE} to ${target}
 
 Resolves Dependabot alert #${ALERT_NUMBER}. The bump installs the highest
-version satisfying the range (>= the advisory's minimum fix); see the lockfile
-diff for the exact resolved version.
+version satisfying the dependency range; the title uses >=<min> when the
+advisory provides a minimum patched version — see the lockfile diff for the exact resolved version.
 Created by BLEnder (https://github.com/mozilla/blender)"
 
   local default_branch parent

--- a/scripts/pr-lib.sh
+++ b/scripts/pr-lib.sh
@@ -78,6 +78,11 @@ bump_alert_line() {
   fi
 }
 
+# Echo the bump version string: ">=<min>" when a patched version is known, else "latest".
+bump_target() {
+  if [ -n "${PATCHED_VERSION:-}" ]; then echo ">=${PATCHED_VERSION}"; else echo "latest"; fi
+}
+
 # Commit a dependency bump (lockfile + package.json) via a verified commit and
 # open a PR. npm-bump.sh and yarn-bump.sh differ only in which lockfile they
 # touch, so both call this. Usage: open_bump_pr LOCKFILE
@@ -108,8 +113,8 @@ open_bump_pr() {
     exit 0
   fi
 
-  local target="latest"
-  [ -n "${PATCHED_VERSION:-}" ] && target=">=${PATCHED_VERSION}"
+  local target
+  target=$(bump_target)
 
   local commit_msg="chore(deps): bump ${PACKAGE} to ${target}
 

--- a/scripts/pr-lib.sh
+++ b/scripts/pr-lib.sh
@@ -108,9 +108,14 @@ open_bump_pr() {
     exit 0
   fi
 
-  local commit_msg="chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}
+  local target="latest"
+  [ -n "${PATCHED_VERSION:-}" ] && target=">=${PATCHED_VERSION}"
 
-Resolves Dependabot alert #${ALERT_NUMBER}.
+  local commit_msg="chore(deps): bump ${PACKAGE} to ${target}
+
+Resolves Dependabot alert #${ALERT_NUMBER}. The bump installs the highest
+version satisfying the range (>= the advisory's minimum fix); see the lockfile
+diff for the exact resolved version.
 Created by BLEnder (https://github.com/mozilla/blender)"
 
   local default_branch parent
@@ -132,7 +137,7 @@ Created by BLEnder (https://github.com/mozilla/blender)"
 
   local run_link_md alert_line
   run_link_md=$(run_link)
-  alert_line=$(bump_alert_line "$REPO" "$PACKAGE" "${PATCHED_VERSION:-}" "$ALERT_NUMBER")
+  alert_line=$(bump_alert_line "$REPO" "$PACKAGE" "$target" "$ALERT_NUMBER")
 
   local pr_body="## Summary
 
@@ -147,7 +152,7 @@ This is a transitive dependency update. Only \`${lockfile}\` (and possibly \`pac
     --repo "$REPO" \
     --head "$branch" \
     --base "$default_branch" \
-    --title "chore(deps): bump ${PACKAGE} to ${PATCHED_VERSION:-latest}" \
+    --title "chore(deps): bump ${PACKAGE} to ${target}" \
     --body "$pr_body"
 
   echo "PR created."


### PR DESCRIPTION
## Bug
Bump PRs are titled `bump <pkg> to <PATCHED_VERSION>`, where `PATCHED_VERSION` is the advisory's `first_patched_version` (the **minimum** fix). But the bump resolves to the highest satisfying version — often higher — so the title understates what ships. On mozilla/fxa#21173 the title said axios "to 1.16.0" but the lockfile shipped **1.20.0** (caught by @vpomerleau).

## Fix (simplest option)
Title/commit/body now say `>=<min>` and point at the lockfile diff for the exact resolved version, rather than claiming a version we didn't pin. No lockfile parsing.

Closes #160.